### PR TITLE
[team-03 : iOS] 3주차 서버에서 이슈 목록 조회, 필터 기능 및 이슈 선택 기능 구현

### DIFF
--- a/iOS/issue-tracker/.swiftlint.yml
+++ b/iOS/issue-tracker/.swiftlint.yml
@@ -2,6 +2,7 @@ disabled_rules:
 - line_length
 - trailing_whitespace
 - vertical_whitespace
+- trailing_comma
 included:
 - issue-tracker
 excluded:

--- a/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
+++ b/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		8F61EB282A1648B90020E302 /* IssueFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F61EB272A1648B90020E302 /* IssueFrame.swift */; };
 		8FB11D842A18D8BC00EDEE45 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB11D832A18D8BC00EDEE45 /* NetworkManager.swift */; };
 		8FB11D862A18E72E00EDEE45 /* IssueFrameHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB11D852A18E72E00EDEE45 /* IssueFrameHolder.swift */; };
+		8FB11D8B2A1C530E00EDEE45 /* FilterOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB11D8A2A1C530E00EDEE45 /* FilterOption.swift */; };
 		8FBE800B2A0B8D8B00D9DA1A /* IssueFilterTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE80092A0B8D8B00D9DA1A /* IssueFilterTableViewCell.swift */; };
 		8FBE800C2A0B8D8B00D9DA1A /* IssueFilterTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8FBE800A2A0B8D8B00D9DA1A /* IssueFilterTableViewCell.xib */; };
 		E4802D9D2A11FD470077B0F4 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4802D9C2A11FD470077B0F4 /* BadgeLabel.swift */; };
@@ -50,6 +51,7 @@
 		8F61EB272A1648B90020E302 /* IssueFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFrame.swift; sourceTree = "<group>"; };
 		8FB11D832A18D8BC00EDEE45 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		8FB11D852A18E72E00EDEE45 /* IssueFrameHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFrameHolder.swift; sourceTree = "<group>"; };
+		8FB11D8A2A1C530E00EDEE45 /* FilterOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterOption.swift; sourceTree = "<group>"; };
 		8FBE80092A0B8D8B00D9DA1A /* IssueFilterTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFilterTableViewCell.swift; sourceTree = "<group>"; };
 		8FBE800A2A0B8D8B00D9DA1A /* IssueFilterTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueFilterTableViewCell.xib; sourceTree = "<group>"; };
 		C4A228AF8694FA3F29925403 /* Pods_issue_tracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_issue_tracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -217,6 +219,7 @@
 				8F61EB252A1642ED0020E302 /* State.swift */,
 				8F61EB272A1648B90020E302 /* IssueFrame.swift */,
 				8FB11D852A18E72E00EDEE45 /* IssueFrameHolder.swift */,
+				8FB11D8A2A1C530E00EDEE45 /* FilterOption.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -380,6 +383,7 @@
 				8FB11D862A18E72E00EDEE45 /* IssueFrameHolder.swift in Sources */,
 				E482789C2A0BAC7700E91FA3 /* IssueCollectionViewCell.swift in Sources */,
 				E48278812A09ED1E00E91FA3 /* IssueTabViewController.swift in Sources */,
+				8FB11D8B2A1C530E00EDEE45 /* FilterOption.swift in Sources */,
 				E48278632A09DAC800E91FA3 /* AppDelegate.swift in Sources */,
 				E4D8AD6A2A162600005BA9BA /* HTTPDataFetcher.swift in Sources */,
 				E4802D9F2A131A8D0077B0F4 /* SubIconView.swift in Sources */,

--- a/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
+++ b/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		8F4456BD2A09E67100EC6B39 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 8F4456BC2A09E67100EC6B39 /* .swiftlint.yml */; };
 		8F61EB262A1642ED0020E302 /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F61EB252A1642ED0020E302 /* State.swift */; };
 		8F61EB282A1648B90020E302 /* IssueFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F61EB272A1648B90020E302 /* IssueFrame.swift */; };
+		8FB11D842A18D8BC00EDEE45 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB11D832A18D8BC00EDEE45 /* NetworkManager.swift */; };
+		8FB11D862A18E72E00EDEE45 /* IssueFrameHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB11D852A18E72E00EDEE45 /* IssueFrameHolder.swift */; };
 		8FBE800B2A0B8D8B00D9DA1A /* IssueFilterTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE80092A0B8D8B00D9DA1A /* IssueFilterTableViewCell.swift */; };
 		8FBE800C2A0B8D8B00D9DA1A /* IssueFilterTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8FBE800A2A0B8D8B00D9DA1A /* IssueFilterTableViewCell.xib */; };
 		E4802D9D2A11FD470077B0F4 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4802D9C2A11FD470077B0F4 /* BadgeLabel.swift */; };
@@ -46,6 +48,8 @@
 		8F4456BC2A09E67100EC6B39 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		8F61EB252A1642ED0020E302 /* State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
 		8F61EB272A1648B90020E302 /* IssueFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFrame.swift; sourceTree = "<group>"; };
+		8FB11D832A18D8BC00EDEE45 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		8FB11D852A18E72E00EDEE45 /* IssueFrameHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFrameHolder.swift; sourceTree = "<group>"; };
 		8FBE80092A0B8D8B00D9DA1A /* IssueFilterTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFilterTableViewCell.swift; sourceTree = "<group>"; };
 		8FBE800A2A0B8D8B00D9DA1A /* IssueFilterTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueFilterTableViewCell.xib; sourceTree = "<group>"; };
 		C4A228AF8694FA3F29925403 /* Pods_issue_tracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_issue_tracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -212,6 +216,7 @@
 				E4D8AD662A1616AA005BA9BA /* Author.swift */,
 				8F61EB252A1642ED0020E302 /* State.swift */,
 				8F61EB272A1648B90020E302 /* IssueFrame.swift */,
+				8FB11D852A18E72E00EDEE45 /* IssueFrameHolder.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -220,6 +225,7 @@
 			isa = PBXGroup;
 			children = (
 				E4D8AD692A162600005BA9BA /* HTTPDataFetcher.swift */,
+				8FB11D832A18D8BC00EDEE45 /* NetworkManager.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -366,10 +372,12 @@
 				E4D8AD612A161679005BA9BA /* Contents.swift in Sources */,
 				E48278672A09DAC800E91FA3 /* LoginViewController.swift in Sources */,
 				8F61EB262A1642ED0020E302 /* State.swift in Sources */,
+				8FB11D842A18D8BC00EDEE45 /* NetworkManager.swift in Sources */,
 				E4D8AD5F2A16166F005BA9BA /* Title.swift in Sources */,
 				E4802D9D2A11FD470077B0F4 /* BadgeLabel.swift in Sources */,
 				8F61EB282A1648B90020E302 /* IssueFrame.swift in Sources */,
 				E4D8AD5D2A161666005BA9BA /* Issue.swift in Sources */,
+				8FB11D862A18E72E00EDEE45 /* IssueFrameHolder.swift in Sources */,
 				E482789C2A0BAC7700E91FA3 /* IssueCollectionViewCell.swift in Sources */,
 				E48278812A09ED1E00E91FA3 /* IssueTabViewController.swift in Sources */,
 				E48278632A09DAC800E91FA3 /* AppDelegate.swift in Sources */,

--- a/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
+++ b/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		E48278A02A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E482789E2A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.swift */; };
 		E48278A12A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E482789F2A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.xib */; };
 		E48B73842A1DCE89009A441C /* IssueSelectingToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48B73832A1DCE89009A441C /* IssueSelectingToolbar.swift */; };
+		E48B73862A1DEA1A009A441C /* AddIssueButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48B73852A1DEA1A009A441C /* AddIssueButton.swift */; };
 		E4D8AD5D2A161666005BA9BA /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D8AD5C2A161666005BA9BA /* Issue.swift */; };
 		E4D8AD5F2A16166F005BA9BA /* Title.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D8AD5E2A16166F005BA9BA /* Title.swift */; };
 		E4D8AD612A161679005BA9BA /* Contents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D8AD602A161679005BA9BA /* Contents.swift */; };
@@ -75,6 +76,7 @@
 		E482789E2A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCollectionViewHeaderCell.swift; sourceTree = "<group>"; };
 		E482789F2A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueCollectionViewHeaderCell.xib; sourceTree = "<group>"; };
 		E48B73832A1DCE89009A441C /* IssueSelectingToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueSelectingToolbar.swift; sourceTree = "<group>"; };
+		E48B73852A1DEA1A009A441C /* AddIssueButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddIssueButton.swift; sourceTree = "<group>"; };
 		E4D8AD5C2A161666005BA9BA /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
 		E4D8AD5E2A16166F005BA9BA /* Title.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Title.swift; sourceTree = "<group>"; };
 		E4D8AD602A161679005BA9BA /* Contents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Contents.swift; sourceTree = "<group>"; };
@@ -197,6 +199,7 @@
 				8FBE800A2A0B8D8B00D9DA1A /* IssueFilterTableViewCell.xib */,
 				E4802D9E2A131A8D0077B0F4 /* SubIconView.swift */,
 				E48B73832A1DCE89009A441C /* IssueSelectingToolbar.swift */,
+				E48B73852A1DEA1A009A441C /* AddIssueButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -375,6 +378,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E48278912A0B771100E91FA3 /* IssueCollectionView.swift in Sources */,
+				E48B73862A1DEA1A009A441C /* AddIssueButton.swift in Sources */,
 				E4D8AD612A161679005BA9BA /* Contents.swift in Sources */,
 				E48278672A09DAC800E91FA3 /* LoginViewController.swift in Sources */,
 				8F61EB262A1642ED0020E302 /* State.swift in Sources */,

--- a/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
+++ b/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		5610FF8ABBD23DCD832DAE04 /* Pods_issue_tracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C4A228AF8694FA3F29925403 /* Pods_issue_tracker.framework */; };
 		8F334AAB2A0B7E7C0070DDEA /* IssueFilterTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F334AAA2A0B7E7C0070DDEA /* IssueFilterTableViewController.swift */; };
 		8F4456BD2A09E67100EC6B39 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 8F4456BC2A09E67100EC6B39 /* .swiftlint.yml */; };
+		8F5204FB2A1DDF4900B49CF0 /* FilterOptionListMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5204FA2A1DDF4900B49CF0 /* FilterOptionListMock.swift */; };
 		8F61EB262A1642ED0020E302 /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F61EB252A1642ED0020E302 /* State.swift */; };
 		8F61EB282A1648B90020E302 /* IssueFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F61EB272A1648B90020E302 /* IssueFrame.swift */; };
 		8FB11D842A18D8BC00EDEE45 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB11D832A18D8BC00EDEE45 /* NetworkManager.swift */; };
@@ -47,6 +48,7 @@
 		6FA8EEB52250DFCA5841EF77 /* Pods-issue-tracker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-issue-tracker.release.xcconfig"; path = "Target Support Files/Pods-issue-tracker/Pods-issue-tracker.release.xcconfig"; sourceTree = "<group>"; };
 		8F334AAA2A0B7E7C0070DDEA /* IssueFilterTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFilterTableViewController.swift; sourceTree = "<group>"; };
 		8F4456BC2A09E67100EC6B39 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		8F5204FA2A1DDF4900B49CF0 /* FilterOptionListMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterOptionListMock.swift; sourceTree = "<group>"; };
 		8F61EB252A1642ED0020E302 /* State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
 		8F61EB272A1648B90020E302 /* IssueFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueFrame.swift; sourceTree = "<group>"; };
 		8FB11D832A18D8BC00EDEE45 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 				8F61EB272A1648B90020E302 /* IssueFrame.swift */,
 				8FB11D852A18E72E00EDEE45 /* IssueFrameHolder.swift */,
 				8FB11D8A2A1C530E00EDEE45 /* FilterOption.swift */,
+				8F5204FA2A1DDF4900B49CF0 /* FilterOptionListMock.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -392,6 +395,7 @@
 				E4D8AD672A1616AA005BA9BA /* Author.swift in Sources */,
 				8FBE800B2A0B8D8B00D9DA1A /* IssueFilterTableViewCell.swift in Sources */,
 				E48278652A09DAC800E91FA3 /* SceneDelegate.swift in Sources */,
+				8F5204FB2A1DDF4900B49CF0 /* FilterOptionListMock.swift in Sources */,
 				E4D8AD652A161692005BA9BA /* Label.swift in Sources */,
 				E48278A02A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.swift in Sources */,
 				E482787C2A09EA3400E91FA3 /* HomeViewController.swift in Sources */,

--- a/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
+++ b/iOS/issue-tracker/issue-tracker.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		E482789D2A0BAC7700E91FA3 /* IssueCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E482789B2A0BAC7700E91FA3 /* IssueCollectionViewCell.xib */; };
 		E48278A02A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E482789E2A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.swift */; };
 		E48278A12A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E482789F2A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.xib */; };
+		E48B73842A1DCE89009A441C /* IssueSelectingToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48B73832A1DCE89009A441C /* IssueSelectingToolbar.swift */; };
 		E4D8AD5D2A161666005BA9BA /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D8AD5C2A161666005BA9BA /* Issue.swift */; };
 		E4D8AD5F2A16166F005BA9BA /* Title.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D8AD5E2A16166F005BA9BA /* Title.swift */; };
 		E4D8AD612A161679005BA9BA /* Contents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D8AD602A161679005BA9BA /* Contents.swift */; };
@@ -73,6 +74,7 @@
 		E482789B2A0BAC7700E91FA3 /* IssueCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueCollectionViewCell.xib; sourceTree = "<group>"; };
 		E482789E2A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCollectionViewHeaderCell.swift; sourceTree = "<group>"; };
 		E482789F2A0C8AEC00E91FA3 /* IssueCollectionViewHeaderCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueCollectionViewHeaderCell.xib; sourceTree = "<group>"; };
+		E48B73832A1DCE89009A441C /* IssueSelectingToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueSelectingToolbar.swift; sourceTree = "<group>"; };
 		E4D8AD5C2A161666005BA9BA /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
 		E4D8AD5E2A16166F005BA9BA /* Title.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Title.swift; sourceTree = "<group>"; };
 		E4D8AD602A161679005BA9BA /* Contents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Contents.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 				8FBE80092A0B8D8B00D9DA1A /* IssueFilterTableViewCell.swift */,
 				8FBE800A2A0B8D8B00D9DA1A /* IssueFilterTableViewCell.xib */,
 				E4802D9E2A131A8D0077B0F4 /* SubIconView.swift */,
+				E48B73832A1DCE89009A441C /* IssueSelectingToolbar.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -384,6 +387,7 @@
 				E482789C2A0BAC7700E91FA3 /* IssueCollectionViewCell.swift in Sources */,
 				E48278812A09ED1E00E91FA3 /* IssueTabViewController.swift in Sources */,
 				8FB11D8B2A1C530E00EDEE45 /* FilterOption.swift in Sources */,
+				E48B73842A1DCE89009A441C /* IssueSelectingToolbar.swift in Sources */,
 				E48278632A09DAC800E91FA3 /* AppDelegate.swift in Sources */,
 				E4D8AD6A2A162600005BA9BA /* HTTPDataFetcher.swift in Sources */,
 				E4802D9F2A131A8D0077B0F4 /* SubIconView.swift in Sources */,

--- a/iOS/issue-tracker/issue-tracker/Home/HomeStoryboard.storyboard
+++ b/iOS/issue-tracker/issue-tracker/Home/HomeStoryboard.storyboard
@@ -138,6 +138,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="backPlane" destination="bus-B5-wOJ" id="Aq5-Pq-9Bg"/>
+                        <outlet property="filterButton" destination="1zk-3q-DS8" id="JY3-Db-cuM"/>
                         <outlet property="selectButton" destination="ZUL-Ft-uWb" id="ZQr-xv-efg"/>
                     </connections>
                 </viewController>

--- a/iOS/issue-tracker/issue-tracker/Home/HomeStoryboard.storyboard
+++ b/iOS/issue-tracker/issue-tracker/Home/HomeStoryboard.storyboard
@@ -58,9 +58,9 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wIp-9r-1pb" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="924" y="-126"/>
+            <point key="canvasLocation" x="1849.6183206106869" y="-126.05633802816902"/>
         </scene>
-        <!--이슈-->
+        <!--Issue Tab View Controller-->
         <scene sceneID="uG2-ZW-Zvr">
             <objects>
                 <viewController id="hgp-X0-zP5" customClass="IssueTabViewController" customModule="issue_tracker" customModuleProvider="target" sceneMemberID="viewController">
@@ -69,42 +69,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bus-B5-wOJ">
-                                <rect key="frame" x="0.0" y="59" width="393" height="710"/>
+                                <rect key="frame" x="0.0" y="103" width="393" height="666"/>
                                 <subviews>
-                                    <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="043-4g-Nc4">
-                                        <rect key="frame" x="0.0" y="-9" width="393" height="44"/>
-                                        <color key="barTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                                        <items>
-                                            <navigationItem id="e36-H7-TrP">
-                                                <barButtonItem key="leftBarButtonItem" style="plain" id="hP7-yc-NZz">
-                                                    <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="top" lineBreakMode="middleTruncation" id="Cuf-1D-390">
-                                                        <rect key="frame" x="16" y="4.6666666666666679" width="54" height="35"/>
-                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                        <state key="normal" title="Button"/>
-                                                        <buttonConfiguration key="configuration" style="plain" title="필터"/>
-                                                        <connections>
-                                                            <segue destination="SGj-EO-sgp" kind="presentation" id="dQy-Qs-LyE"/>
-                                                        </connections>
-                                                    </button>
-                                                    <color key="tintColor" name="AccentColor"/>
-                                                    <connections>
-                                                        <action selector="btn:" destination="hgp-X0-zP5" id="fdK-sZ-Lyn"/>
-                                                    </connections>
-                                                </barButtonItem>
-                                                <barButtonItem key="rightBarButtonItem" style="plain" id="0VV-ab-vqX">
-                                                    <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="lZF-VX-dp6">
-                                                        <rect key="frame" x="323" y="4.6666666666666679" width="54" height="35"/>
-                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                        <state key="normal" title="Button"/>
-                                                        <buttonConfiguration key="configuration" style="plain" title="선택"/>
-                                                    </button>
-                                                    <color key="tintColor" name="AccentColor"/>
-                                                </barButtonItem>
-                                            </navigationItem>
-                                        </items>
-                                    </navigationBar>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="tnt-wc-ugX" customClass="IssueCollectionView" customModule="issue_tracker" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="35" width="393" height="675"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="666"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="sHQ-Wb-be0">
                                             <size key="itemSize" width="137" height="131"/>
@@ -126,13 +94,10 @@
                                     </collectionView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="043-4g-Nc4" firstAttribute="width" secondItem="bus-B5-wOJ" secondAttribute="width" id="BV3-Cr-GYf"/>
-                                    <constraint firstItem="tnt-wc-ugX" firstAttribute="top" secondItem="043-4g-Nc4" secondAttribute="bottom" id="GjI-by-C5M"/>
-                                    <constraint firstItem="043-4g-Nc4" firstAttribute="top" secondItem="bus-B5-wOJ" secondAttribute="top" constant="-9" id="SWt-Bx-Mxt"/>
-                                    <constraint firstItem="tnt-wc-ugX" firstAttribute="trailing" secondItem="043-4g-Nc4" secondAttribute="trailing" id="XLM-Kw-N12"/>
-                                    <constraint firstItem="043-4g-Nc4" firstAttribute="centerX" secondItem="bus-B5-wOJ" secondAttribute="centerX" id="bmS-Wt-CXm"/>
-                                    <constraint firstItem="tnt-wc-ugX" firstAttribute="height" secondItem="bus-B5-wOJ" secondAttribute="height" multiplier="0.950704" id="sK5-6z-C4m"/>
-                                    <constraint firstItem="tnt-wc-ugX" firstAttribute="leading" secondItem="043-4g-Nc4" secondAttribute="leading" id="shQ-Ai-4L0"/>
+                                    <constraint firstItem="tnt-wc-ugX" firstAttribute="centerY" secondItem="bus-B5-wOJ" secondAttribute="centerY" id="3Q4-dy-yKv"/>
+                                    <constraint firstItem="tnt-wc-ugX" firstAttribute="leading" secondItem="bus-B5-wOJ" secondAttribute="leading" id="EdZ-YL-zLd"/>
+                                    <constraint firstItem="tnt-wc-ugX" firstAttribute="top" secondItem="bus-B5-wOJ" secondAttribute="top" id="Xbr-Gz-FKg"/>
+                                    <constraint firstItem="tnt-wc-ugX" firstAttribute="centerX" secondItem="bus-B5-wOJ" secondAttribute="centerX" id="y3j-fM-nYc"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -143,24 +108,49 @@
                             <constraint firstItem="bus-B5-wOJ" firstAttribute="top" secondItem="ef0-Tg-bER" secondAttribute="top" id="CiU-eR-vsO"/>
                             <constraint firstItem="ef0-Tg-bER" firstAttribute="bottom" secondItem="bus-B5-wOJ" secondAttribute="bottom" id="a1R-7O-kzt"/>
                             <constraint firstItem="bus-B5-wOJ" firstAttribute="centerX" secondItem="ef0-Tg-bER" secondAttribute="centerX" id="d5f-O1-KBk"/>
-                            <constraint firstItem="ef0-Tg-bER" firstAttribute="bottom" secondItem="tnt-wc-ugX" secondAttribute="bottom" id="ioZ-Il-hpf"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="이슈" image="property=exclamation" id="Tjq-5B-gcQ"/>
+                    <navigationItem key="navigationItem" id="RoA-pw-PkY">
+                        <barButtonItem key="leftBarButtonItem" style="plain" id="1zk-3q-DS8">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="top" lineBreakMode="middleTruncation" id="SHC-dP-BFv">
+                                <rect key="frame" x="16" y="4.6666666666666679" width="54" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="필터"/>
+                                <connections>
+                                    <action selector="filterButtonTouched:" destination="hgp-X0-zP5" eventType="touchUpInside" id="fRc-8K-9Pn"/>
+                                </connections>
+                            </button>
+                            <color key="tintColor" name="AccentColor"/>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" style="plain" id="ZUL-Ft-uWb">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="1ju-08-vxk">
+                                <rect key="frame" x="323" y="4.6666666666666679" width="54" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="선택"/>
+                                <connections>
+                                    <action selector="selectButtonTouched:" destination="hgp-X0-zP5" eventType="touchUpInside" id="PeW-Df-rBZ"/>
+                                </connections>
+                            </button>
+                            <color key="tintColor" name="AccentColor"/>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="backPlane" destination="bus-B5-wOJ" id="Aq5-Pq-9Bg"/>
+                        <outlet property="selectButton" destination="ZUL-Ft-uWb" id="ZQr-xv-efg"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="BZw-fe-jY9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="922.90076335877859" y="-733.09859154929586"/>
+            <point key="canvasLocation" x="1850" y="-733"/>
         </scene>
         <!--Issue Filter Table View Controller-->
         <scene sceneID="1Ce-N6-5OY">
             <objects>
                 <tableViewController id="Yfx-Yi-e9y" customClass="IssueFilterTableViewController" customModule="issue_tracker" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="ebC-yO-QKr">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
@@ -182,7 +172,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="XwH-KB-smv" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2643.5114503816794" y="-733.09859154929586"/>
+            <point key="canvasLocation" x="3883" y="-837"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="b8P-6g-gzi">
@@ -194,7 +184,7 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>
                     <connections>
-                        <segue destination="hgp-X0-zP5" kind="relationship" relationship="viewControllers" id="43n-b4-60m"/>
+                        <segue destination="KwX-S8-4iJ" kind="relationship" relationship="viewControllers" id="43n-b4-60m"/>
                         <segue destination="F8v-26-MJN" kind="relationship" relationship="viewControllers" id="4JA-HO-xiw"/>
                         <segue destination="E4d-6A-TPY" kind="relationship" relationship="viewControllers" id="8vh-g6-cdg"/>
                         <segue destination="U3B-Id-ukx" kind="relationship" relationship="viewControllers" id="IDO-bb-UGM"/>
@@ -209,8 +199,9 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="SGj-EO-sgp" sceneMemberID="viewController">
                     <toolbarItems/>
+                    <navigationItem key="navigationItem" id="5bI-WM-NC3"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="hGN-Vw-O3m">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="56"/>
+                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -220,7 +211,26 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lwR-4N-9WD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1716.7938931297708" y="-733.09859154929586"/>
+            <point key="canvasLocation" x="3060" y="-837"/>
+        </scene>
+        <!--이슈-->
+        <scene sceneID="Zj0-GD-eeX">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="KwX-S8-4iJ" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="이슈" image="property=exclamation" id="Tjq-5B-gcQ"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="GZe-fD-04p">
+                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="hgp-X0-zP5" kind="relationship" relationship="rootViewController" id="Xao-Th-apV"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="8Hr-Sw-isf" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="922.90076335877859" y="-733.09859154929586"/>
         </scene>
     </scenes>
     <resources>

--- a/iOS/issue-tracker/issue-tracker/Home/HomeStoryboard.storyboard
+++ b/iOS/issue-tracker/issue-tracker/Home/HomeStoryboard.storyboard
@@ -138,6 +138,7 @@
                     </navigationItem>
                     <connections>
                         <outlet property="backPlane" destination="bus-B5-wOJ" id="Aq5-Pq-9Bg"/>
+                        <outlet property="collectionView" destination="tnt-wc-ugX" id="HIt-UD-vPo"/>
                         <outlet property="filterButton" destination="1zk-3q-DS8" id="JY3-Db-cuM"/>
                         <outlet property="selectButton" destination="ZUL-Ft-uWb" id="ZQr-xv-efg"/>
                     </connections>

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -43,7 +43,7 @@ class IssueFilterTableViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         if let cell = tableView.cellForRow(at: indexPath) as? IssueFilterTableViewCell {
-            cell.toggleImage()
+            cell.toggleSelecting()
         }
     }
     

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 class IssueFilterTableViewController: UITableViewController {
     private let checkmarkImage = UIImage(systemName: "checkmark")
     private let grayCheckmarkImage = UIImage(systemName: "checkmark")?.withTintColor(.gray, renderingMode: .alwaysOriginal)
+    weak var delegate: UIViewController?
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 class IssueFilterTableViewController: UITableViewController {
     private let checkmarkImage = UIImage(systemName: "checkmark")
     private let grayCheckmarkImage = UIImage(systemName: "checkmark")?.withTintColor(.gray, renderingMode: .alwaysOriginal)
-    weak var delegate: UIViewController?
+    weak var delegate: IssueTabViewController?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -27,9 +27,9 @@ class IssueFilterTableViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
-        case 0: return 2
-        case 1: return 3
-        case 2: return 4
+        case 0: return 4
+        case 1: return 4
+        case 2: return 2
         default: return 1
         }
     }
@@ -84,6 +84,8 @@ class IssueFilterTableViewController: UITableViewController {
     
     @objc func saveAction() {
         // TODO: Convey filter options to previous VC
+        
+        delegate?.fetchData(with: "")
         dismissSelf()
     }
     

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -85,7 +85,7 @@ class IssueFilterTableViewController: UITableViewController {
     @objc func saveAction() {
         // TODO: Convey filter options to previous VC
         
-        delegate?.fetchData(with: "")
+        delegate?.fetchData()
         dismissSelf()
     }
     
@@ -93,4 +93,3 @@ class IssueFilterTableViewController: UITableViewController {
         self.dismiss(animated: true, completion: nil)
     }
 }
-

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -95,39 +95,6 @@ class IssueFilterTableViewController: UITableViewController {
     }
 }
 
-struct FilterOptionListMock: FilterOptionsLike {
-    var list: [[FilterOption]] = [
-        [
-            FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "{close=true}", isSelected: false)
-        ],
-        [
-            FilterOption(filterLabel: "chloe", filterUrlStr: nil),
-            FilterOption(filterLabel: "head", filterUrlStr: nil),
-            FilterOption(filterLabel: "sam", filterUrlStr: nil),
-            FilterOption(filterLabel: "zello", filterUrlStr: nil)
-        ],
-        [
-            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil, isSelected: false),
-            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false)
-        ]
-    ]
-    
-    func collectSelectedFilterOptionUrlString() -> String {
-        var collectedOptionUrlString = "?"
-        
-        for options in list {
-            for option in options {
-                guard let urlStr = option.filterUrlStr else { continue }
-                collectedOptionUrlString += option.isSelected ? urlStr : ""
-            }
-        }
-        return collectedOptionUrlString.count == 1 ? "" : collectedOptionUrlString
-    }
-}
-
 protocol FilterOptionsLike {
     var list: [[FilterOption]] { get set }
     func collectSelectedFilterOptionUrlString() -> String

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 class IssueFilterTableViewController: UITableViewController {
+    
+
     private let checkmarkImage = UIImage(systemName: "checkmark")
     private let grayCheckmarkImage = UIImage(systemName: "checkmark")?.withTintColor(.gray, renderingMode: .alwaysOriginal)
     
@@ -74,7 +76,7 @@ class IssueFilterTableViewController: UITableViewController {
     }
     
     private func configureSaveButton() {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "저장", style: .plain, target: self, action: #selector(saveAction))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "저장  ", style: .plain, target: self, action: #selector(saveAction))
     }
     
     @objc func backAction() {
@@ -82,12 +84,11 @@ class IssueFilterTableViewController: UITableViewController {
     }
     
     @objc func saveAction() {
-        // TODO: Convey filter options to previous VC
         dismissSelf()
     }
     
     private func dismissSelf() {
-        self.dismiss(animated: true, completion: nil)
+        navigationController?.popViewController(animated: true)
     }
 }
 

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -8,10 +8,9 @@
 import UIKit
 
 class IssueFilterTableViewController: UITableViewController {
-    
-
     private let checkmarkImage = UIImage(systemName: "checkmark")
     private let grayCheckmarkImage = UIImage(systemName: "checkmark")?.withTintColor(.gray, renderingMode: .alwaysOriginal)
+    var filterOptionList: FilterOptionsLike = FilterOptionListMock()
     weak var delegate: IssueTabViewController?
     
     override func viewDidLoad() {
@@ -22,11 +21,11 @@ class IssueFilterTableViewController: UITableViewController {
         configureBackButton()
         configureSaveButton()
     }
-
+    
     override func numberOfSections(in tableView: UITableView) -> Int {
         return 3
     }
-
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
         case 0: return 4
@@ -35,11 +34,11 @@ class IssueFilterTableViewController: UITableViewController {
         default: return 1
         }
     }
-
+    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "filterOptionCell", for: indexPath) as? IssueFilterTableViewCell else { return UITableViewCell() }
-        cell.configureWith(filterOption: FilterOption(filterLabel: "Test", filterUrlStr: nil), selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
+        cell.configureWith(filterOption: filterOptionList.list[indexPath.section][indexPath.row], selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
         return cell
     }
     
@@ -51,7 +50,7 @@ class IssueFilterTableViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection
-                                section: Int) -> String? {
+                            section: Int) -> String? {
         switch section {
         case 0: return "상태"
         case 1: return "담당자"
@@ -92,4 +91,29 @@ class IssueFilterTableViewController: UITableViewController {
     private func dismissSelf() {
         navigationController?.popViewController(animated: true)
     }
+}
+
+struct FilterOptionListMock: FilterOptionsLike {
+    let list: [[FilterOption]] = [
+        [
+            FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "?{close=true}"),
+        ],
+        [
+            FilterOption(filterLabel: "chloe", filterUrlStr: nil),
+            FilterOption(filterLabel: "head", filterUrlStr: nil),
+            FilterOption(filterLabel: "sam", filterUrlStr: nil),
+            FilterOption(filterLabel: "zello", filterUrlStr: nil),
+        ],
+        [
+            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil),
+            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil),
+        ],
+    ]
+}
+
+protocol FilterOptionsLike {
+    var list: [[FilterOption]] { get }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -28,9 +28,9 @@ class IssueFilterTableViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
-        case 0: return 4
-        case 1: return 4
-        case 2: return 2
+        case 0: return filterOptionList.list[0].count
+        case 1: return filterOptionList.list[1].count
+        case 2: return filterOptionList.list[2].count
         default: return 1
         }
     }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -101,18 +101,18 @@ struct FilterOptionListMock: FilterOptionsLike {
             FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "{close=true}", isSelected: false),
+            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "{close=true}", isSelected: false)
         ],
         [
             FilterOption(filterLabel: "chloe", filterUrlStr: nil),
             FilterOption(filterLabel: "head", filterUrlStr: nil),
             FilterOption(filterLabel: "sam", filterUrlStr: nil),
-            FilterOption(filterLabel: "zello", filterUrlStr: nil),
+            FilterOption(filterLabel: "zello", filterUrlStr: nil)
         ],
         [
             FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil, isSelected: false),
-            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false),
-        ],
+            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false)
+        ]
     ]
     
     func collectSelectedFilterOptionUrlString() -> String {

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -65,6 +65,23 @@ class IssueFilterTableViewController: UITableViewController {
         return num
     }
     
+    private func dismissSelf() {
+        navigationController?.popViewController(animated: true)
+    }
+}
+
+protocol FilterOptionsLike {
+    var list: [[FilterOption]] { get set }
+    func collectSelectedFilterOptionUrlString() -> String
+}
+
+protocol IssueTabViewControllerLike {
+    func setUrlString(with: String)
+    func fetchData()
+}
+
+// 취소, 저장 버튼
+extension IssueFilterTableViewController {
     private func configureBackButton() {
         let backbutton = UIButton(type: .custom)
         backbutton.setImage(UIImage(systemName: "chevron.left"), for: .normal)
@@ -89,18 +106,4 @@ class IssueFilterTableViewController: UITableViewController {
         delegate?.fetchData()
         dismissSelf()
     }
-    
-    private func dismissSelf() {
-        navigationController?.popViewController(animated: true)
-    }
-}
-
-protocol FilterOptionsLike {
-    var list: [[FilterOption]] { get set }
-    func collectSelectedFilterOptionUrlString() -> String
-}
-
-protocol IssueTabViewControllerLike {
-    func setUrlString(with: String)
-    func fetchData()
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -39,7 +39,7 @@ class IssueFilterTableViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "filterOptionCell", for: indexPath) as? IssueFilterTableViewCell else { return UITableViewCell() }
-        cell.configureWith(optionName: "Filter option", selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
+        cell.configureWith(filterOption: FilterOption(filterLabel: "Test", filterUrlStr: nil), selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
         return cell
     }
     

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 class IssueFilterTableViewController: UITableViewController {
     private let checkmarkImage = UIImage(systemName: "checkmark")
     private let grayCheckmarkImage = UIImage(systemName: "checkmark")?.withTintColor(.gray, renderingMode: .alwaysOriginal)
-    var filterOptionList: FilterOptionsLike = FilterOptionListMock()
+    var filterOptionList: FilterOptionsLike?
     weak var delegate: IssueTabViewController?
     
     override func viewDidLoad() {
@@ -28,24 +28,25 @@ class IssueFilterTableViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
-        case 0: return filterOptionList.list[0].count
-        case 1: return filterOptionList.list[1].count
-        case 2: return filterOptionList.list[2].count
+        case 0: return filterOptionList?.list[0].count ?? 1
+        case 1: return filterOptionList?.list[1].count ?? 1
+        case 2: return filterOptionList?.list[2].count ?? 1
         default: return 1
         }
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-                guard let cell = tableView.dequeueReusableCell(withIdentifier: "filterOptionCell", for: indexPath) as? IssueFilterTableViewCell else { return UITableViewCell() }
-        cell.configureWith(filterOption: filterOptionList.list[indexPath.section][indexPath.row], selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
-                return cell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "filterOptionCell", for: indexPath) as? IssueFilterTableViewCell else { return UITableViewCell() }
+        guard let filterOption = filterOptionList?.list[indexPath.section][indexPath.row] else { return UITableViewCell() }
+        cell.configureWith(filterOption: filterOption, selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
+        return cell
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         if let cell = tableView.cellForRow(at: indexPath) as? IssueFilterTableViewCell {
             cell.toggleSelecting()
-            filterOptionList.list[indexPath.section][indexPath.row].isSelected.toggle()
+            filterOptionList?.list[indexPath.section][indexPath.row].isSelected.toggle()
         }
     }
     
@@ -101,9 +102,9 @@ extension IssueFilterTableViewController {
     }
     
     @objc func saveAction() {
-        let newUrlString = filterOptionList.collectSelectedFilterOptionUrlString()
+        let filterUrlString = delegate?.filterOptionList.collectSelectedFilterOptionUrlString() ?? ""
+        let newUrlString = "http://3.38.73.117:8080/api-ios/issues" + filterUrlString
         delegate?.setUrlString(with: newUrlString)
-        delegate?.fetchData()
         dismissSelf()
     }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -36,16 +36,16 @@ class IssueFilterTableViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "filterOptionCell", for: indexPath) as? IssueFilterTableViewCell else { return UITableViewCell() }
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: "filterOptionCell", for: indexPath) as? IssueFilterTableViewCell else { return UITableViewCell() }
         cell.configureWith(filterOption: filterOptionList.list[indexPath.section][indexPath.row], selectedImage: checkmarkImage, deselectedImage: grayCheckmarkImage)
-        return cell
+                return cell
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         if let cell = tableView.cellForRow(at: indexPath) as? IssueFilterTableViewCell {
             cell.toggleSelecting()
+            filterOptionList.list[indexPath.section][indexPath.row].isSelected.toggle()
         }
     }
     
@@ -84,6 +84,8 @@ class IssueFilterTableViewController: UITableViewController {
     }
     
     @objc func saveAction() {
+        let newUrlString = filterOptionList.collectSelectedFilterOptionUrlString()
+        delegate?.setUrlString(with: newUrlString)
         delegate?.fetchData()
         dismissSelf()
     }
@@ -94,12 +96,12 @@ class IssueFilterTableViewController: UITableViewController {
 }
 
 struct FilterOptionListMock: FilterOptionsLike {
-    let list: [[FilterOption]] = [
+    var list: [[FilterOption]] = [
         [
             FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "?{close=true}", isSelected: false),
+            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "{close=true}", isSelected: false),
         ],
         [
             FilterOption(filterLabel: "chloe", filterUrlStr: nil),
@@ -112,8 +114,21 @@ struct FilterOptionListMock: FilterOptionsLike {
             FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false),
         ],
     ]
+    
+    func collectSelectedFilterOptionUrlString() -> String {
+        var collectedOptionUrlString = "?"
+        
+        for options in list {
+            for option in options {
+                guard let urlStr = option.filterUrlStr else { continue }
+                collectedOptionUrlString += option.isSelected ? urlStr : ""
+            }
+        }
+        return collectedOptionUrlString.count == 1 ? "" : collectedOptionUrlString
+    }
 }
 
 protocol FilterOptionsLike {
-    var list: [[FilterOption]] { get }
+    var list: [[FilterOption]] { get set }
+    func collectSelectedFilterOptionUrlString() -> String
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -132,3 +132,8 @@ protocol FilterOptionsLike {
     var list: [[FilterOption]] { get set }
     func collectSelectedFilterOptionUrlString() -> String
 }
+
+protocol IssueTabViewControllerLike {
+    func setUrlString(with: String)
+    func fetchData()
+}

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueFilterTableViewController.swift
@@ -99,7 +99,7 @@ struct FilterOptionListMock: FilterOptionsLike {
             FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "?{close=true}"),
+            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "?{close=true}", isSelected: false),
         ],
         [
             FilterOption(filterLabel: "chloe", filterUrlStr: nil),
@@ -108,8 +108,8 @@ struct FilterOptionListMock: FilterOptionsLike {
             FilterOption(filterLabel: "zello", filterUrlStr: nil),
         ],
         [
-            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil),
-            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil),
+            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil, isSelected: false),
+            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false),
         ],
     ]
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -42,8 +42,13 @@ class IssueTabViewController: UIViewController {
         }
     }
     
-    func fetchData(with urlString: String) {
-        guard let url = URL(string: urlString) else { return }
+    func fetchData() {
+        guard let url = URL(string: currentIssueDataUrlString) else {
+            self.logger.log(
+                "Invalie URL string : \(self.currentIssueDataUrlString)")
+            return
+        }
+        
         networkManager.fetchIssueData(with: url) { result in
             switch result {
             case .success(let issueFrameHolder):

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -35,6 +35,10 @@ class IssueTabViewController: UIViewController {
         setAddIssueButton()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        fetchData()
+    }
+    
     private func setAddIssueButton() {
         addIssueButton = AddIssueButton(radius: self.view.frame.height * 56 / 666)
         guard let addIssueButton = addIssueButton else {
@@ -71,10 +75,6 @@ class IssueTabViewController: UIViewController {
             return
         }
         self.view.addSubview(toolBar)
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        fetchData()
     }
     
     private func setCancelButton() {

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -63,4 +63,8 @@ class IssueTabViewController: UIViewController {
             }
         }
     }
+    
+    func setUrlString(with urlString: String) {
+        currentIssueDataUrlString = urlString
+    }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -38,6 +38,7 @@ class IssueTabViewController: UIViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let navigationController = segue.destination as? UINavigationController{
             let filterTableViewController = navigationController.topViewController as? IssueFilterTableViewController
+            filterTableViewController?.delegate = self
         }
     }
     

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -23,6 +23,11 @@ class IssueTabViewController: UIViewController {
             switch result {
             case .success(let issueFrameHolder):
                 self.issueFrames = issueFrameHolder.issues
+                guard let issueFrames = self.issueFrames else { return }
+                self.collectionView.issueFrames = issueFrames
+                DispatchQueue.main.async {
+                    self.collectionView.reloadData()
+                }
             case .failure(let error):
                 self.logger.error("error : \(error)")
             }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -19,6 +19,7 @@ class IssueTabViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         backPlane.addSubview(collectionView)
+        // TODO: fetchData(with: String)로 대체 예정
         networkManager.fetchIssueData { result in
             switch result {
             case .success(let issueFrameHolder):
@@ -37,6 +38,23 @@ class IssueTabViewController: UIViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let navigationController = segue.destination as? UINavigationController{
             let filterTableViewController = navigationController.topViewController as? IssueFilterTableViewController
+        }
+    }
+    
+    func fetchData(with urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        networkManager.fetchIssueData(with: url) { result in
+            switch result {
+            case .success(let issueFrameHolder):
+                self.issueFrames = issueFrameHolder.issues
+                guard let issueFrames = self.issueFrames else { return }
+                self.collectionView.issueFrames = issueFrames
+                DispatchQueue.main.async {
+                    self.collectionView.reloadData()
+                }
+            case .failure(let error):
+                self.logger.error("error : \(error)")
+            }
         }
     }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -6,24 +6,27 @@
 //
 
 import UIKit
+import OSLog
 
 class IssueTabViewController: UIViewController {
+    let logger = Logger()
     let fetcher = HTTPDataFetcher()
+    let networkManager = NetworkManager()
+    var issueFrames: [IssueFrame]?
     
     let collectionView = IssueCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     @IBOutlet var backPlane: UIView!
     override func viewDidLoad() {
         super.viewDidLoad()
         backPlane.addSubview(collectionView)
-        
-        fetcher.fetchIssueData(completion: { result in
+        networkManager.fetchIssueData { result in
             switch result {
-            case .success(let jsonString):
-                print(jsonString)
+            case .success(let issueFrameHolder):
+                self.issueFrames = issueFrameHolder.issues
             case .failure(let error):
-                print(error.localizedDescription)
+                self.logger.error("error : \(error)")
             }
-        })
+        }
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -9,10 +9,10 @@ import UIKit
 import OSLog
 
 class IssueTabViewController: UIViewController {
-    let logger = Logger()
-    let fetcher = HTTPDataFetcher()
-    let networkManager = NetworkManager()
-    var issueFrames: [IssueFrame]?
+    private let logger = Logger()
+    private let networkManager = NetworkManager()
+    private var issueFrames: [IssueFrame]?
+    private var currentIssueDataUrlString: String = "http://3.38.73.117:8080/api-ios/issues"
     
     let collectionView = IssueCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     @IBOutlet var backPlane: UIView!

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -47,6 +47,7 @@ class IssueTabViewController: UIViewController, IssueCollectionViewDelegate {
             cell.subIconView.change(isCheckmarked: isPlus)
             cell.updateSubIconViewConstraints()
         }
+    }
 
     override func viewWillAppear(_ animated: Bool) {
         fetchData()

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -30,6 +30,7 @@ class IssueTabViewController: UIViewController, IssueCollectionViewDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        collectionView.collectionViewDelegate = self
         setCancelButton()
         setToolbar()
         setAddIssueButton()

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -12,7 +12,7 @@ class IssueTabViewController: UIViewController {
     
     @IBOutlet var filterButton: UIBarButtonItem!
     @IBOutlet var selectButton: UIBarButtonItem!
-    
+    @IBOutlet var collectionView: IssueCollectionView!
     var cancelButton: UIBarButtonItem?
     let nothingButton = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
     
@@ -23,21 +23,19 @@ class IssueTabViewController: UIViewController {
     private var issueFrames: [IssueFrame]?
     private var currentIssueDataUrlString: String = "http://3.38.73.117:8080/api-ios/issues"
     
-//    let collectionView = IssueCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     @IBOutlet var backPlane: UIView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-//        backPlane.addSubview(collectionView)
         // TODO: fetchData(with: String)로 대체 예정
         networkManager.fetchIssueData { result in
             switch result {
             case .success(let issueFrameHolder):
                 self.issueFrames = issueFrameHolder.issues
                 guard let issueFrames = self.issueFrames else { return }
-//                self.collectionView.issueFrames = issueFrames
+                self.collectionView.issueFrames = issueFrames
                 DispatchQueue.main.async {
-//                    self.collectionView.reloadData()
+                    self.collectionView.reloadData()
                 }
             case .failure(let error):
                 self.logger.error("error : \(error)")
@@ -83,10 +81,10 @@ class IssueTabViewController: UIViewController {
             case .success(let issueFrameHolder):
                 self.issueFrames = issueFrameHolder.issues
                 guard let issueFrames = self.issueFrames else { return }
-//                self.collectionView.issueFrames = issueFrames
-//                DispatchQueue.main.async {
-//                    self.collectionView.reloadData()
-//                }
+                self.collectionView.issueFrames = issueFrames
+                DispatchQueue.main.async {
+                    self.collectionView.reloadData()
+                }
             case .failure(let error):
                 self.logger.error("error : \(error)")
             }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import OSLog
 
 class IssueTabViewController: UIViewController {
+    private var toolBar : UIToolbar? = nil
     
     @IBOutlet var filterButton: UIBarButtonItem!
     @IBOutlet var selectButton: UIBarButtonItem!
@@ -42,6 +43,40 @@ class IssueTabViewController: UIViewController {
             }
         }
         setCancelButton()
+        setToolbar()
+    }
+    
+    private func setToolBarItems() -> [UIBarButtonItem] {
+        let rightItem = UIBarButtonItem(image: UIImage(systemName: "archivebox"), style: .plain, target: nil, action: nil)
+        //TODO: 이슈 선택 개수에 따라 title 변경 기능
+        let titleItem = UIBarButtonItem(title: "이슈를 선택하세요.", style: .done, target: nil, action: nil)
+        
+        titleItem.isEnabled = false
+        
+        
+        let leftItem = UIBarButtonItem(image: UIImage(systemName: "checkmark.circle"), style: .plain, target: nil, action: nil)
+        
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        
+        
+        return([leftItem, flexibleSpace, titleItem, flexibleSpace, rightItem])
+    }
+    
+    private func setToolbar() {
+        guard let tabBar = self.tabBarController?.tabBar else {
+            return
+        }
+        let frame = CGRect(origin: tabBar.frame.origin, size: CGSize(width: tabBar.frame.width, height: tabBar.frame.height/2))
+        
+        self.toolBar = UIToolbar(frame: frame)
+        
+        guard let toolBar = self.toolBar else {
+            return
+        }
+        toolBar.items = setToolBarItems()
+        toolBar.isHidden = true
+        toolBar.barTintColor = .white
+        self.view.addSubview(toolBar)
     }
     
     private func setCancelButton() {
@@ -55,7 +90,7 @@ class IssueTabViewController: UIViewController {
     
     @IBAction func selectButtonTouched(_ sender: UIButton) {
         
-        self.navigationController?.isToolbarHidden = false
+        self.toolBar?.isHidden = false
         self.tabBarController?.tabBar.isHidden = true
         self.navigationItem.leftBarButtonItem = nothingButton
         
@@ -63,7 +98,7 @@ class IssueTabViewController: UIViewController {
     }
     
     @objc private func cancelButtonTouched() {
-        self.navigationController?.isToolbarHidden = true
+        self.toolBar?.isHidden = true
         self.tabBarController?.tabBar.isHidden = false
         self.navigationItem.leftBarButtonItem = filterButton
         self.navigationItem.rightBarButtonItem = selectButton

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -14,6 +14,7 @@ class IssueTabViewController: UIViewController {
     @IBOutlet var collectionView: IssueCollectionView!
     var cancelButton: UIBarButtonItem?
     let nothingButton = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+    var filterOptionList: FilterOptionsLike = FilterOptionListMock()
     
     let fetcher = HTTPDataFetcher()
     
@@ -39,6 +40,8 @@ class IssueTabViewController: UIViewController {
     
     @IBAction func filterButtonTouched(_ sender: UIButton) {
         let filterTableViewController = IssueFilterTableViewController()
+        filterTableViewController.delegate = self
+        filterTableViewController.filterOptionList = filterOptionList
         show(filterTableViewController, sender: sender)
     }
     

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -9,14 +9,14 @@ import UIKit
 import OSLog
 
 class IssueTabViewController: UIViewController {
-
+    
     
     @IBOutlet var selectButton: UIBarButtonItem!
     
     var cancelButton: UIBarButtonItem?
     
     let fetcher = HTTPDataFetcher()
-
+    
     private let logger = Logger()
     private let networkManager = NetworkManager()
     private var issueFrames: [IssueFrame]?
@@ -41,7 +41,7 @@ class IssueTabViewController: UIViewController {
             case .failure(let error):
                 self.logger.error("error : \(error)")
             }
-        })
+        }
         setCancelButton()
     }
     
@@ -69,15 +69,6 @@ class IssueTabViewController: UIViewController {
         self.navigationItem.leftBarButtonItem?.isHidden = false
         self.navigationItem.rightBarButtonItem = selectButton
     }
-        }
-    }
-    
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if let navigationController = segue.destination as? UINavigationController{
-            let filterTableViewController = navigationController.topViewController as? IssueFilterTableViewController
-            filterTableViewController?.delegate = self
-        }
-    }
     
     func fetchData() {
         guard let url = URL(string: currentIssueDataUrlString) else {
@@ -104,5 +95,6 @@ class IssueTabViewController: UIViewController {
     func setUrlString(with urlString: String) {
         currentIssueDataUrlString = urlString
     }
-
 }
+
+

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -23,21 +23,21 @@ class IssueTabViewController: UIViewController {
     private var issueFrames: [IssueFrame]?
     private var currentIssueDataUrlString: String = "http://3.38.73.117:8080/api-ios/issues"
     
-    let collectionView = IssueCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+//    let collectionView = IssueCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     @IBOutlet var backPlane: UIView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        backPlane.addSubview(collectionView)
+//        backPlane.addSubview(collectionView)
         // TODO: fetchData(with: String)로 대체 예정
         networkManager.fetchIssueData { result in
             switch result {
             case .success(let issueFrameHolder):
                 self.issueFrames = issueFrameHolder.issues
                 guard let issueFrames = self.issueFrames else { return }
-                self.collectionView.issueFrames = issueFrames
+//                self.collectionView.issueFrames = issueFrames
                 DispatchQueue.main.async {
-                    self.collectionView.reloadData()
+//                    self.collectionView.reloadData()
                 }
             case .failure(let error):
                 self.logger.error("error : \(error)")
@@ -83,10 +83,10 @@ class IssueTabViewController: UIViewController {
             case .success(let issueFrameHolder):
                 self.issueFrames = issueFrameHolder.issues
                 guard let issueFrames = self.issueFrames else { return }
-                self.collectionView.issueFrames = issueFrames
-                DispatchQueue.main.async {
-                    self.collectionView.reloadData()
-                }
+//                self.collectionView.issueFrames = issueFrames
+//                DispatchQueue.main.async {
+//                    self.collectionView.reloadData()
+//                }
             case .failure(let error):
                 self.logger.error("error : \(error)")
             }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -42,9 +42,13 @@ class IssueTabViewController: UIViewController, IssueCollectionViewDelegate {
             guard let cell = collectionView.cellForItem(at: indexPath) as? IssueCollectionViewCell else {
                 return
             }
+            guard let toolBar = self.toolBar else {
+                return
+            }
+            
             cell.isCheckmarked.toggle()
             let isPlus = cell.isCheckmarked
-            self.toolBar!.updateTitle(isPlus: isPlus)
+            toolBar.updateTitle(isPlus: isPlus)
             cell.subIconView.change(isCheckmarked: isPlus)
             cell.updateSubIconViewConstraints()
         }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -10,10 +10,11 @@ import OSLog
 
 class IssueTabViewController: UIViewController {
     
-    
+    @IBOutlet var filterButton: UIBarButtonItem!
     @IBOutlet var selectButton: UIBarButtonItem!
     
     var cancelButton: UIBarButtonItem?
+    let nothingButton = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
     
     let fetcher = HTTPDataFetcher()
     
@@ -58,7 +59,7 @@ class IssueTabViewController: UIViewController {
         
         self.navigationController?.isToolbarHidden = false
         self.tabBarController?.tabBar.isHidden = true
-        self.navigationItem.leftBarButtonItem?.isHidden = true
+        self.navigationItem.leftBarButtonItem = nothingButton
         
         self.navigationItem.rightBarButtonItem = cancelButton
     }
@@ -66,7 +67,7 @@ class IssueTabViewController: UIViewController {
     @objc private func cancelButtonTouched() {
         self.navigationController?.isToolbarHidden = true
         self.tabBarController?.tabBar.isHidden = false
-        self.navigationItem.leftBarButtonItem?.isHidden = false
+        self.navigationItem.leftBarButtonItem = filterButton
         self.navigationItem.rightBarButtonItem = selectButton
     }
     

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 import OSLog
 
 class IssueTabViewController: UIViewController {
-    
     @IBOutlet var filterButton: UIBarButtonItem!
     @IBOutlet var selectButton: UIBarButtonItem!
     @IBOutlet var collectionView: IssueCollectionView!
@@ -27,21 +26,11 @@ class IssueTabViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // TODO: fetchData(with: String)로 대체 예정
-        networkManager.fetchIssueData { result in
-            switch result {
-            case .success(let issueFrameHolder):
-                self.issueFrames = issueFrameHolder.issues
-                guard let issueFrames = self.issueFrames else { return }
-                self.collectionView.issueFrames = issueFrames
-                DispatchQueue.main.async {
-                    self.collectionView.reloadData()
-                }
-            case .failure(let error):
-                self.logger.error("error : \(error)")
-            }
-        }
         setCancelButton()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        fetchData()
     }
     
     private func setCancelButton() {
@@ -54,7 +43,6 @@ class IssueTabViewController: UIViewController {
     }
     
     @IBAction func selectButtonTouched(_ sender: UIButton) {
-        
         self.navigationController?.isToolbarHidden = false
         self.tabBarController?.tabBar.isHidden = true
         self.navigationItem.leftBarButtonItem = nothingButton
@@ -69,13 +57,12 @@ class IssueTabViewController: UIViewController {
         self.navigationItem.rightBarButtonItem = selectButton
     }
     
-    func fetchData() {
+    private func fetchData() {
         guard let url = URL(string: currentIssueDataUrlString) else {
             self.logger.log(
                 "Invalie URL string : \(self.currentIssueDataUrlString)")
             return
         }
-        
         networkManager.fetchIssueData(with: url) { result in
             switch result {
             case .success(let issueFrameHolder):
@@ -95,5 +82,3 @@ class IssueTabViewController: UIViewController {
         currentIssueDataUrlString = urlString
     }
 }
-
-

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 import OSLog
 
 class IssueTabViewController: UIViewController {
+    
+    private var addIssueButton: AddIssueButton?
     private var toolBar: UIToolbar?
     @IBOutlet var filterButton: UIBarButtonItem!
     @IBOutlet var selectButton: UIBarButtonItem!
@@ -43,6 +45,29 @@ class IssueTabViewController: UIViewController {
         }
         setCancelButton()
         setToolbar()
+        setAddIssueButton()
+    }
+    
+    private func setAddIssueButton() {
+        addIssueButton = AddIssueButton(radius: self.view.frame.height * 56 / 666)
+        guard let addIssueButton = addIssueButton else {
+            return
+        }
+        self.view.addSubview(addIssueButton)
+        setIssueAddButtonConstraints(button: addIssueButton)
+    }
+    
+    private func setIssueAddButtonConstraints(button: UIButton) {
+        
+        let length = self.view.frame.height * 56 / 666
+        
+        button.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            button.heightAnchor.constraint(equalToConstant: length),
+            button.widthAnchor.constraint(equalToConstant: length),
+            button.bottomAnchor.constraint(equalTo: self.collectionView.bottomAnchor, constant: -length/2),
+            button.trailingAnchor.constraint(equalTo: self.collectionView.trailingAnchor, constant: -length/2)
+        ])
     }
     
     private func calculateToolBarFrame() -> CGRect {

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -57,6 +57,8 @@ class IssueTabViewController: UIViewController, IssueCollectionViewDelegate {
             cell.isCheckmarked.toggle()
             let isPlus = cell.isCheckmarked
             self.toolBar!.updateTitle(isPlus: isPlus)
+            cell.subIconView.change(isCheckmarked: isPlus)
+            cell.updateSubIconViewConstraints()
         }
     }
     

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -9,8 +9,7 @@ import UIKit
 import OSLog
 
 class IssueTabViewController: UIViewController {
-    private var toolBar : UIToolbar? = nil
-    
+    private var toolBar: UIToolbar?
     @IBOutlet var filterButton: UIBarButtonItem!
     @IBOutlet var selectButton: UIBarButtonItem!
     @IBOutlet var collectionView: IssueCollectionView!
@@ -46,36 +45,19 @@ class IssueTabViewController: UIViewController {
         setToolbar()
     }
     
-    private func setToolBarItems() -> [UIBarButtonItem] {
-        let rightItem = UIBarButtonItem(image: UIImage(systemName: "archivebox"), style: .plain, target: nil, action: nil)
-        //TODO: 이슈 선택 개수에 따라 title 변경 기능
-        let titleItem = UIBarButtonItem(title: "이슈를 선택하세요.", style: .done, target: nil, action: nil)
-        
-        titleItem.isEnabled = false
-        
-        
-        let leftItem = UIBarButtonItem(image: UIImage(systemName: "checkmark.circle"), style: .plain, target: nil, action: nil)
-        
-        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-        
-        
-        return([leftItem, flexibleSpace, titleItem, flexibleSpace, rightItem])
+    private func calculateToolBarFrame() -> CGRect {
+        guard let tabBar = self.tabBarController?.tabBar else {
+            return CGRect()
+        }
+        let frame = CGRect(origin: tabBar.frame.origin, size: CGSize(width: tabBar.frame.width, height: tabBar.frame.height/2))
+        return frame
     }
     
     private func setToolbar() {
-        guard let tabBar = self.tabBarController?.tabBar else {
-            return
-        }
-        let frame = CGRect(origin: tabBar.frame.origin, size: CGSize(width: tabBar.frame.width, height: tabBar.frame.height/2))
-        
-        self.toolBar = UIToolbar(frame: frame)
-        
+        self.toolBar = IssueSelectingToolbar(frame: calculateToolBarFrame())
         guard let toolBar = self.toolBar else {
             return
         }
-        toolBar.items = setToolBarItems()
-        toolBar.isHidden = true
-        toolBar.barTintColor = .white
         self.view.addSubview(toolBar)
     }
     
@@ -89,11 +71,9 @@ class IssueTabViewController: UIViewController {
     }
     
     @IBAction func selectButtonTouched(_ sender: UIButton) {
-        
         self.toolBar?.isHidden = false
         self.tabBarController?.tabBar.isHidden = true
         self.navigationItem.leftBarButtonItem = nothingButton
-        
         self.navigationItem.rightBarButtonItem = cancelButton
     }
     

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -8,9 +8,10 @@
 import UIKit
 import OSLog
 
-class IssueTabViewController: UIViewController {
+class IssueTabViewController: UIViewController, IssueCollectionViewDelegate {
+    private var isSelectionMode: Bool = false
     private var addIssueButton: AddIssueButton?
-    private var toolBar: UIToolbar?
+    private var toolBar: IssueSelectingToolbar?
     @IBOutlet var filterButton: UIBarButtonItem!
     @IBOutlet var selectButton: UIBarButtonItem!
     @IBOutlet var collectionView: IssueCollectionView!
@@ -28,6 +29,7 @@ class IssueTabViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        collectionView.collectionViewDelegate = self
         // TODO: fetchData(with: String)로 대체 예정
         networkManager.fetchIssueData { result in
             switch result {
@@ -44,8 +46,18 @@ class IssueTabViewController: UIViewController {
         }
         setCancelButton()
         setToolbar()
-
         setAddIssueButton()
+    }
+    
+    func didSelectCell(in collectionView: IssueCollectionView, at indexPath: IndexPath) {
+        if isSelectionMode == true {
+            guard let cell = collectionView.cellForItem(at: indexPath) as? IssueCollectionViewCell else {
+                return
+            }
+            cell.isCheckmarked.toggle()
+            let isPlus = cell.isCheckmarked
+            self.toolBar!.updateTitle(isPlus: isPlus)
+        }
     }
     
     private func setAddIssueButton() {
@@ -100,6 +112,8 @@ class IssueTabViewController: UIViewController {
         self.tabBarController?.tabBar.isHidden = true
         self.navigationItem.leftBarButtonItem = nothingButton
         self.navigationItem.rightBarButtonItem = cancelButton
+        self.addIssueButton?.isHidden = true
+        self.isSelectionMode.toggle()
     }
     
     @objc private func cancelButtonTouched() {
@@ -107,6 +121,8 @@ class IssueTabViewController: UIViewController {
         self.tabBarController?.tabBar.isHidden = false
         self.navigationItem.leftBarButtonItem = filterButton
         self.navigationItem.rightBarButtonItem = selectButton
+        self.addIssueButton?.isHidden = false
+        self.isSelectionMode.toggle()
     }
     
     func fetchData() {
@@ -136,4 +152,7 @@ class IssueTabViewController: UIViewController {
     }
 }
 
+protocol IssueCollectionViewDelegate: AnyObject {
+    func didSelectCell(in collectionView: IssueCollectionView, at indexPath: IndexPath)
+}
 

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Controllers/IssueTabViewController.swift
@@ -8,10 +8,16 @@
 import UIKit
 
 class IssueTabViewController: UIViewController {
+    
+    @IBOutlet var selectButton: UIBarButtonItem!
+    
+    var cancelButton: UIBarButtonItem?
+    
     let fetcher = HTTPDataFetcher()
     
     let collectionView = IssueCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     @IBOutlet var backPlane: UIView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         backPlane.addSubview(collectionView)
@@ -24,11 +30,33 @@ class IssueTabViewController: UIViewController {
                 print(error.localizedDescription)
             }
         })
+        setCancelButton()
+    }
+
+    
+    private func setCancelButton() {
+        cancelButton = UIBarButtonItem(title: "취소  ", style: .plain, target: self, action: #selector(cancelButtonTouched))
     }
     
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if let navigationController = segue.destination as? UINavigationController{
-            let filterTableViewController = navigationController.topViewController as? IssueFilterTableViewController
-        }
+    @IBAction func filterButtonTouched(_ sender: UIButton) {
+        let filterTableViewController = IssueFilterTableViewController()
+        show(filterTableViewController, sender: sender)
     }
+    
+    @IBAction func selectButtonTouched(_ sender: UIButton) {
+        
+        self.navigationController?.isToolbarHidden = false
+        self.tabBarController?.tabBar.isHidden = true
+        self.navigationItem.leftBarButtonItem?.isHidden = true
+        
+        self.navigationItem.rightBarButtonItem = cancelButton
+    }
+    
+    @objc private func cancelButtonTouched() {
+        self.navigationController?.isToolbarHidden = true
+        self.tabBarController?.tabBar.isHidden = false
+        self.navigationItem.leftBarButtonItem?.isHidden = false
+        self.navigationItem.rightBarButtonItem = selectButton
+    }
+
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOption.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOption.swift
@@ -1,0 +1,13 @@
+//
+//  FilterOption.swift
+//  issue-tracker
+//
+//  Created by 에디 on 2023/05/23.
+//
+
+import Foundation
+
+struct FilterOption {
+    let filterLabel: String
+    let filterUrlStr: String?
+}

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOption.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOption.swift
@@ -10,4 +10,11 @@ import Foundation
 struct FilterOption {
     let filterLabel: String
     let filterUrlStr: String?
+    var isSelected: Bool
+    
+    init(filterLabel: String, filterUrlStr: String?, isSelected: Bool = true) {
+        self.filterLabel = filterLabel
+        self.filterUrlStr = filterUrlStr
+        self.isSelected = isSelected
+    }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOption.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOption.swift
@@ -12,7 +12,7 @@ struct FilterOption {
     let filterUrlStr: String?
     var isSelected: Bool
     
-    init(filterLabel: String, filterUrlStr: String?, isSelected: Bool = true) {
+    init(filterLabel: String, filterUrlStr: String?, isSelected: Bool = false) {
         self.filterLabel = filterLabel
         self.filterUrlStr = filterUrlStr
         self.isSelected = isSelected

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOptionListMock.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOptionListMock.swift
@@ -10,32 +10,46 @@ import Foundation
 class FilterOptionListMock: FilterOptionsLike {
     var list: [[FilterOption]] = [
         [
-            FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "열린 이슈", filterUrlStr: "state=true"),
             FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
             FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
-            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "{close=true}", isSelected: false)
+            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "state=false"),
         ],
         [
-            FilterOption(filterLabel: "chloe", filterUrlStr: nil),
-            FilterOption(filterLabel: "head", filterUrlStr: nil),
-            FilterOption(filterLabel: "sam", filterUrlStr: nil),
-            FilterOption(filterLabel: "zello", filterUrlStr: nil)
+            // 현재 assignee의 id로 필터링 가능, 중첩 사용은 안됌
+            FilterOption(filterLabel: "ghkdgus29", filterUrlStr: "assignee=ghkdgus29"),
+            FilterOption(filterLabel: "cire", filterUrlStr: "assignee=cire"),
         ],
         [
-            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil, isSelected: false),
-            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false)
+            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil),
+            FilterOption(filterLabel: "BE STEP1", filterUrlStr: nil),
         ]
     ]
     
     func collectSelectedFilterOptionUrlString() -> String {
+        // 필터 적용 형태 : 기본 URL + ?key1=value1&key2=value2
+        // labelNames의 경우 : 기본 URL + ?라벨이름키=라벨1,라벨2
         var collectedOptionUrlString = "?"
         
-        for options in list {
-            for option in options {
+        var urlString = ""
+        for index in 0...1 {
+            for option in list[index] {
                 guard let urlStr = option.filterUrlStr else { continue }
-                collectedOptionUrlString += option.isSelected ? urlStr : ""
+                collectedOptionUrlString += option.isSelected ? urlStr + "&" : ""
             }
         }
+        _ = urlString.popLast()
+        
+        var labelUrlString = ""
+        for option in list[2] {
+            guard let urlStr = option.filterUrlStr else { continue }
+            collectedOptionUrlString += option.isSelected ? urlStr + "," : ""
+        }
+        _ = labelUrlString.popLast()
+        
+        collectedOptionUrlString += urlString
+        collectedOptionUrlString += labelUrlString
+        
         return collectedOptionUrlString.count == 1 ? "" : collectedOptionUrlString
     }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOptionListMock.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOptionListMock.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct FilterOptionListMock: FilterOptionsLike {
+class FilterOptionListMock: FilterOptionsLike {
     var list: [[FilterOption]] = [
         [
             FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOptionListMock.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/FilterOptionListMock.swift
@@ -1,0 +1,41 @@
+//
+//  FilterOptionListMock.swift
+//  issue-tracker
+//
+//  Created by 에디 on 2023/05/24.
+//
+
+import Foundation
+
+struct FilterOptionListMock: FilterOptionsLike {
+    var list: [[FilterOption]] = [
+        [
+            FilterOption(filterLabel: "열린 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "내가 작성한 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "내가 댓글을 남긴 이슈", filterUrlStr: nil),
+            FilterOption(filterLabel: "닫힌 이슈", filterUrlStr: "{close=true}", isSelected: false)
+        ],
+        [
+            FilterOption(filterLabel: "chloe", filterUrlStr: nil),
+            FilterOption(filterLabel: "head", filterUrlStr: nil),
+            FilterOption(filterLabel: "sam", filterUrlStr: nil),
+            FilterOption(filterLabel: "zello", filterUrlStr: nil)
+        ],
+        [
+            FilterOption(filterLabel: "레이블 없음", filterUrlStr: nil, isSelected: false),
+            FilterOption(filterLabel: "그룹프로젝트:이슈트래커", filterUrlStr: nil, isSelected: false)
+        ]
+    ]
+    
+    func collectSelectedFilterOptionUrlString() -> String {
+        var collectedOptionUrlString = "?"
+        
+        for options in list {
+            for option in options {
+                guard let urlStr = option.filterUrlStr else { continue }
+                collectedOptionUrlString += option.isSelected ? urlStr : ""
+            }
+        }
+        return collectedOptionUrlString.count == 1 ? "" : collectedOptionUrlString
+    }
+}

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/IssueFrame.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/IssueFrame.swift
@@ -15,7 +15,7 @@ struct IssueFrame: Codable {
     let createdDate: String
     let lastUpdatedDate: String
 //    let author: String
-    let milestone: Milestone
+    let milestone: Milestone?
     let user: User
     let labels: [Label]
     let assignees: [User]

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/IssueFrame.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/IssueFrame.swift
@@ -8,10 +8,23 @@
 import Foundation
 
 struct IssueFrame: Codable {
+    let number: Int
     let title: String
     let contents: String
-    let milestone: String
-    let labels: [Label]
     let state: Bool
-    let author: String
+    let createdDate: String
+    let lastUpdatedDate: String
+//    let author: String
+    let milestone: Milestone
+    let user: User
+    let labels: [Label]
+    let assignees: [User]
 }
+
+struct User: Codable {
+    let id: String
+    let password: String
+    let nickname: String
+    let imgUrl: String
+}
+

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/IssueFrameHolder.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/IssueFrameHolder.swift
@@ -1,0 +1,12 @@
+//
+//  IssueFrameHolder.swift
+//  issue-tracker
+//
+//  Created by 에디 on 2023/05/20.
+//
+
+import Foundation
+
+struct IssueFrameHolder: Codable {
+    let issues: [IssueFrame]
+}

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Models/Milestone.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Models/Milestone.swift
@@ -7,6 +7,9 @@
 
 import Foundation
 
-struct Milestone {
+struct Milestone: Codable {
     let name: String
+    let scheduledCompletionDate: String
+    let descriptionForLabel: String
+    let empty: Bool
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/AddIssueButton.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/AddIssueButton.swift
@@ -1,0 +1,36 @@
+//
+//  AddIssueButton.swift
+//  issue-tracker
+//
+//  Created by SONG on 2023/05/24.
+//
+
+import UIKit
+
+class AddIssueButton: UIButton {
+    private var radius: CGFloat? = nil
+    init(radius: CGFloat) {
+        super.init(frame: .zero)
+        self.radius = radius
+        setFigure()
+    
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setFigure()
+    }
+
+    
+    private func setFigure() {
+        guard let radius = radius else {
+            return
+        }
+        self.layer.cornerRadius = radius/2
+        self.backgroundColor = .tintColor
+        self.setTitle("+", for: .normal)
+        self.setTitleColor(.white, for: .normal)
+        self.titleLabel?.textAlignment = .center
+        self.titleLabel?.font = .systemFont(ofSize: radius/2, weight: .light)
+    }
+}

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/BadgeLabel.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/BadgeLabel.swift
@@ -64,7 +64,7 @@ class BadgeLabel: UILabel {
         case "adfqewersdfsqasd":
             self.backgroundColor = UIColor(red: 0.0, green: 0.478, blue: 1, alpha: 1.0)
         default:
-            break
+            self.backgroundColor = UIColor(red: 0.0, green: 0.478, blue: 1, alpha: 1.0)
         }
         self.textColor = .white
     }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/BadgeLabel.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/BadgeLabel.swift
@@ -34,7 +34,7 @@ class BadgeLabel: UILabel {
         self.clipsToBounds = true
         self.layer.cornerRadius = 15
         
-        self.font = UIFont.systemFont(ofSize: superview.frame.height / 2.6, weight: .regular)
+        self.font = UIFont.systemFont(ofSize: round(superview.frame.height / 2.6), weight: .regular)
         
         let font = self.font
         let text = self.text ?? ""
@@ -47,7 +47,8 @@ class BadgeLabel: UILabel {
         
         NSLayoutConstraint.activate([
             self.widthAnchor.constraint(equalToConstant: textWidth + superview.frame.height),
-            self.heightAnchor.constraint(equalTo: superview.heightAnchor, multiplier: 0.8),
+//            self.heightAnchor.constraint(equalTo: superview.heightAnchor, multiplier: 0.8),
+            self.bottomAnchor.constraint(equalTo: superview.bottomAnchor),
             self.centerYAnchor.constraint(equalTo: superview.centerYAnchor)
         ])
     }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionView.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionView.swift
@@ -9,6 +9,12 @@ import UIKit
 import SwipeCellKit
 
 class IssueCollectionView: UICollectionView {
+    var issueFrames: [IssueFrame] = [
+        IssueFrame(number: 1, title: "Test-1", contents: "Test1Contents", state: true, createdDate: "123", lastUpdatedDate: "123", milestone: Milestone(name: "MilestoneName", scheduledCompletionDate: "123", descriptionForLabel: "milestoneDescription", empty: false), user: User(id: "testId", password: "123", nickname: "Eddie", imgUrl: "www."), labels: [Label(name: "TestLabel", textColor: "color", backgroundColor: "color")], assignees: []),
+        IssueFrame(number: 2, title: "Test-2", contents: "Test2Contents", state: false, createdDate: "213", lastUpdatedDate: "123", milestone: Milestone(name: "MilestoneName", scheduledCompletionDate: "123", descriptionForLabel: "milestoneDescription", empty: false), user: User(id: "testId2", password: "123", nickname: "Eddie2", imgUrl: "www."), labels: [Label(name: "TestLabel1", textColor: "color", backgroundColor: "color")], assignees: [])
+    
+    ]
+    
     override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         super.init(frame: frame, collectionViewLayout: layout)
         self.delegate = self
@@ -32,7 +38,8 @@ extension IssueCollectionView: UICollectionViewDelegate {
 
 extension IssueCollectionView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 15
+        return self.issueFrames.count
+        
     }
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
@@ -40,9 +47,10 @@ extension IssueCollectionView: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: IssueCollectionViewCell.identifier, for: indexPath) as? SwipeCollectionViewCell else {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: IssueCollectionViewCell.identifier, for: indexPath) as? IssueCollectionViewCell else {
             return UICollectionViewCell()
         }
+        cell.configure(with: self.issueFrames[indexPath.item])
         cell.delegate = self
         return cell
     }
@@ -99,7 +107,9 @@ extension IssueCollectionView: SwipeCollectionViewCellDelegate {
             return nil
         }
         
-        let delete = SwipeAction(style: .destructive, title: "삭제") { action, indexPath in }
+        let delete = SwipeAction(style: .destructive, title: "삭제") { action, indexPath in
+            self.issueFrames.remove(at: indexPath.item)
+        }
         
         delete.image = UIImage(systemName: "trash")
         

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionView.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionView.swift
@@ -113,7 +113,7 @@ extension IssueCollectionView: SwipeCollectionViewCellDelegate {
         
         exit.image = UIImage(systemName: "archivebox")
         exit.backgroundColor = UIColor(red: 0.329, green: 0.227, blue: 0.745, alpha: 1)
-
+        
         return [delete, exit]
     }
     

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionView.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionView.swift
@@ -10,6 +10,7 @@ import SwipeCellKit
 
 class IssueCollectionView: UICollectionView {
     var issueFrames = [IssueFrame]()
+    weak var collectionViewDelegate: IssueCollectionViewDelegate?
     
     override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         super.init(frame: frame, collectionViewLayout: layout)
@@ -30,6 +31,9 @@ class IssueCollectionView: UICollectionView {
 }
 
 extension IssueCollectionView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        collectionViewDelegate?.didSelectCell(in: self, at: indexPath)
+    }
 }
 
 extension IssueCollectionView: UICollectionViewDataSource {
@@ -124,4 +128,3 @@ extension IssueCollectionView: SwipeCollectionViewCellDelegate {
         return options
     }
 }
-

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionView.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionView.swift
@@ -9,11 +9,7 @@ import UIKit
 import SwipeCellKit
 
 class IssueCollectionView: UICollectionView {
-    var issueFrames: [IssueFrame] = [
-        IssueFrame(number: 1, title: "Test-1", contents: "Test1Contents", state: true, createdDate: "123", lastUpdatedDate: "123", milestone: Milestone(name: "MilestoneName", scheduledCompletionDate: "123", descriptionForLabel: "milestoneDescription", empty: false), user: User(id: "testId", password: "123", nickname: "Eddie", imgUrl: "www."), labels: [Label(name: "TestLabel", textColor: "color", backgroundColor: "color")], assignees: []),
-        IssueFrame(number: 2, title: "Test-2", contents: "Test2Contents", state: false, createdDate: "213", lastUpdatedDate: "123", milestone: Milestone(name: "MilestoneName", scheduledCompletionDate: "123", descriptionForLabel: "milestoneDescription", empty: false), user: User(id: "testId2", password: "123", nickname: "Eddie2", imgUrl: "www."), labels: [Label(name: "TestLabel1", textColor: "color", backgroundColor: "color")], assignees: [])
-    
-    ]
+    var issueFrames = [IssueFrame]()
     
     override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         super.init(frame: frame, collectionViewLayout: layout)

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
@@ -23,15 +23,69 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
         setTitle()
         setStackView()
         setBadge()
+        setContents()
+        setMilestoneImage()
+        setMilestone()
     }
     private func setTitle() {
         title.text = "iOS 이슈트래커 개발"
+        
+        title.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            title.topAnchor.constraint(equalTo: self.topAnchor),
+            title.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: self.frame.width * 20 / 322),
+            title.trailingAnchor.constraint(equalTo: self.trailingAnchor,constant: -(self.frame.width * 30 / 322)),
+            title.heightAnchor.constraint(equalToConstant: self.frame.height * 34 / 131)
+        ])
+        
+    }
+    
+    private func setContents() {
+        contents.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            contents.heightAnchor.constraint(equalToConstant: self.frame.height * 30 / 131),
+            contents.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: self.frame.width * 20 / 322),
+            contents.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            contents.topAnchor.constraint(equalTo: title.bottomAnchor )
+        ])
+    }
+    
+    private func setMilestoneImage() {
+        milestoneImage.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            milestoneImage.heightAnchor.constraint(equalToConstant: self.frame.height * 30 / 131),
+            milestoneImage.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: self.frame.width * 20 / 322),
+            milestoneImage.topAnchor.constraint(equalTo: contents.bottomAnchor),
+            milestoneImage.widthAnchor.constraint(equalTo: milestoneImage.heightAnchor)
+        ])
+    }
+    
+    private func setMilestone() {
+        milestone.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            milestone.heightAnchor.constraint(equalToConstant: self.frame.height * 30 / 131),
+            milestone.leadingAnchor.constraint(equalTo: milestoneImage.trailingAnchor, constant: self.frame.width * 4 / 375),
+            milestone.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            milestone.topAnchor.constraint(equalTo: contents.bottomAnchor )
+        ])
     }
     
     private func setStackView() {
         labelsStackView.axis = .horizontal
         labelsStackView.spacing = 10
         labelsStackView.distribution = .fill
+        
+        labelsStackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            labelsStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: self.frame.height/3),
+            labelsStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: self.frame.width * 20 / 322),
+            labelsStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+        ])
     }
     
     private func setBadge() {

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
@@ -38,7 +38,6 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
             title.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: round(-(self.frame.width * 30 / 322))),
             title.heightAnchor.constraint(equalToConstant: round(self.frame.height * 34 / 131))
         ])
-        
     }
     
     private func setContents() {
@@ -82,9 +81,10 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
         labelsStackView.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            labelsStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: round(self.frame.height/3)),
+            labelsStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: round(self.frame.height/2.6 )),
             labelsStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: round(self.frame.width * 20 / 322)),
-            labelsStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+            labelsStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            labelsStackView.heightAnchor.constraint(equalToConstant: round(self.frame.height * 30 / 131))
         ])
     }
     

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
@@ -34,9 +34,9 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
         
         NSLayoutConstraint.activate([
             title.topAnchor.constraint(equalTo: self.topAnchor),
-            title.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: self.frame.width * 20 / 322),
-            title.trailingAnchor.constraint(equalTo: self.trailingAnchor,constant: -(self.frame.width * 30 / 322)),
-            title.heightAnchor.constraint(equalToConstant: self.frame.height * 34 / 131)
+            title.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: round(self.frame.width * 20 / 322)),
+            title.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: round(-(self.frame.width * 30 / 322))),
+            title.heightAnchor.constraint(equalToConstant: round(self.frame.height * 34 / 131))
         ])
         
     }
@@ -45,8 +45,8 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
         contents.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            contents.heightAnchor.constraint(equalToConstant: self.frame.height * 30 / 131),
-            contents.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: self.frame.width * 20 / 322),
+            contents.heightAnchor.constraint(equalToConstant: round(self.frame.height * 30 / 131)),
+            contents.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: round(self.frame.width * 20 / 322)),
             contents.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             contents.topAnchor.constraint(equalTo: title.bottomAnchor )
         ])
@@ -56,8 +56,8 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
         milestoneImage.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            milestoneImage.heightAnchor.constraint(equalToConstant: self.frame.height * 30 / 131),
-            milestoneImage.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: self.frame.width * 20 / 322),
+            milestoneImage.heightAnchor.constraint(equalToConstant: round(self.frame.height * 30 / 131.0)),
+            milestoneImage.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: round(self.frame.width * 20.0 / 322.0)),
             milestoneImage.topAnchor.constraint(equalTo: contents.bottomAnchor),
             milestoneImage.widthAnchor.constraint(equalTo: milestoneImage.heightAnchor)
         ])
@@ -67,8 +67,8 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
         milestone.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            milestone.heightAnchor.constraint(equalToConstant: self.frame.height * 30 / 131),
-            milestone.leadingAnchor.constraint(equalTo: milestoneImage.trailingAnchor, constant: self.frame.width * 4 / 375),
+            milestone.heightAnchor.constraint(equalToConstant: round(self.frame.height * 30 / 131)),
+            milestone.leadingAnchor.constraint(equalTo: milestoneImage.trailingAnchor, constant: round(self.frame.width * 4 / 375)),
             milestone.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             milestone.topAnchor.constraint(equalTo: contents.bottomAnchor )
         ])
@@ -82,8 +82,8 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
         labelsStackView.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            labelsStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: self.frame.height/3),
-            labelsStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: self.frame.width * 20 / 322),
+            labelsStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: round(self.frame.height/3)),
+            labelsStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: round(self.frame.width * 20 / 322)),
             labelsStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
         ])
     }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
@@ -22,7 +22,7 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
         super.awakeFromNib()
         setTitle()
         setStackView()
-        setBadge()
+//        setBadge() : configure 메소드로 이동
         setContents()
         setMilestoneImage()
         setMilestone()
@@ -100,6 +100,7 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
         contents.text = issueFrame.contents
         milestone.text = issueFrame.milestone.name
         badges = issueFrame.labels.map { $0.name }
+        setBadge()
     }
 }
 

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
@@ -16,7 +16,7 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
     @IBOutlet var milestone: UILabel!
     @IBOutlet var labelsStackView: UIStackView!
     
-    let badges = ["sfgs","gggassfsdfg","adfqewersdfsqasd"]
+    var badges = ["sfgs","gggassfsdfg","adfqewersdfsqasd"]
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -39,6 +39,13 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
             labelsStackView.addArrangedSubview(BadgeLabel(name: item))
         }
         labelsStackView.addArrangedSubview(UIView(frame: CGRect()))
+    }
+    
+    func configure(with issueFrame: IssueFrame) {
+        title.text = issueFrame.title
+        contents.text = issueFrame.contents
+        milestone.text = issueFrame.milestone.name
+        badges = issueFrame.labels.map { $0.name }
     }
 }
 

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
@@ -27,6 +27,12 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
         setMilestoneImage()
         setMilestone()
     }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        labelsStackView.arrangedSubviews.forEach { view in view.removeFromSuperview() }
+    }
+    
     private func setTitle() {
         title.text = "iOS 이슈트래커 개발"
         

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
@@ -138,7 +138,7 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
     func configure(with issueFrame: IssueFrame) {
         title.text = issueFrame.title
         contents.text = issueFrame.contents
-        milestone.text = issueFrame.milestone.name
+        milestone.text = issueFrame.milestone?.name
         badges = issueFrame.labels.map { $0.name }
         setBadge()
     }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
@@ -15,6 +15,7 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
     @IBOutlet var milestoneImage: UIImageView!
     @IBOutlet var milestone: UILabel!
     @IBOutlet var labelsStackView: UIStackView!
+    @IBOutlet var subIconView: SubIconView!
     
     var badges = ["sfgs","gggassfsdfg","adfqewersdfsqasd"]
     
@@ -26,6 +27,17 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
         setContents()
         setMilestoneImage()
         setMilestone()
+        setSubIconView()
+    }
+    private func setSubIconView() {
+        subIconView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            subIconView.centerXAnchor.constraint(equalTo: self.trailingAnchor, constant: self.frame.height / -6),
+            subIconView.centerYAnchor.constraint(equalTo: title.centerYAnchor),
+            subIconView.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 25 / 148),
+            subIconView.widthAnchor.constraint(equalTo: subIconView.heightAnchor, multiplier: 0.7)
+        ])
     }
     private func setTitle() {
         title.text = "iOS 이슈트래커 개발"

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.swift
@@ -17,6 +17,8 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
     @IBOutlet var labelsStackView: UIStackView!
     @IBOutlet var subIconView: SubIconView!
     
+    var isCheckmarked: Bool = false
+    
     var badges = ["sfgs","gggassfsdfg","adfqewersdfsqasd"]
     
     override func awakeFromNib() {
@@ -39,6 +41,28 @@ class IssueCollectionViewCell: SwipeCollectionViewCell {
             subIconView.widthAnchor.constraint(equalTo: subIconView.heightAnchor, multiplier: 0.7)
         ])
     }
+    
+    func updateSubIconViewConstraints() {
+        NSLayoutConstraint.deactivate(subIconView.constraints)
+        
+        if isCheckmarked {
+            NSLayoutConstraint.activate([
+                subIconView.centerXAnchor.constraint(equalTo: self.trailingAnchor, constant: self.frame.height / -6),
+                subIconView.centerYAnchor.constraint(equalTo: title.centerYAnchor),
+                subIconView.heightAnchor.constraint(equalTo: subIconView.heightAnchor),
+                subIconView.widthAnchor.constraint(equalTo: subIconView.heightAnchor)
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                subIconView.centerXAnchor.constraint(equalTo: self.trailingAnchor, constant: self.frame.height / -6),
+                subIconView.centerYAnchor.constraint(equalTo: title.centerYAnchor),
+                subIconView.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 25 / 148),
+                subIconView.widthAnchor.constraint(equalTo: subIconView.heightAnchor, multiplier: 0.7)
+            ])
+        }
+    }
+    
+    
     private func setTitle() {
         title.text = "iOS 이슈트래커 개발"
         

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.xib
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.xib
@@ -17,38 +17,35 @@
                 <rect key="frame" x="0.0" y="0.0" width="393" height="131"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ne7-SF-c0Q" userLabel="title">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ne7-SF-c0Q" userLabel="title">
                         <rect key="frame" x="20" y="7" width="322" height="34"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="34" id="Dxb-4o-gxk"/>
-                        </constraints>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Contents" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bOe-il-Mrh">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Contents" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bOe-il-Mrh">
                         <rect key="frame" x="20" y="44" width="372" height="21"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="21" id="Ite-wN-GIw"/>
-                        </constraints>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                         <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Milestone" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="op5-ox-cAC">
-                        <rect key="frame" x="54" y="67" width="339" height="20.333333333333329"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Milestone" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="op5-ox-cAC">
+                        <rect key="frame" x="319" y="67" width="74" height="20.333333333333329"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="signpost.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="q9F-pn-4B5">
-                        <rect key="frame" x="20" y="68.333333333333329" width="28" height="19.666666666666671"/>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" ambiguous="YES" image="signpost.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="q9F-pn-4B5">
+                        <rect key="frame" x="285" y="68.333333333333314" width="28" height="19.666666666666671"/>
                         <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="28" id="Bi7-Qv-LqL"/>
                         </constraints>
                     </imageView>
-                    <stackView opaque="NO" contentMode="scaleAspectFit" distribution="equalSpacing" spacing="10" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BeV-Tu-p6V">
+                    <stackView opaque="NO" contentMode="scaleAspectFit" ambiguous="YES" distribution="equalSpacing" spacing="10" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BeV-Tu-p6V">
                         <rect key="frame" x="0.0" y="87" width="393" height="39"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="BeV-Tu-p6V" secondAttribute="height" multiplier="353:35" id="SpP-Ym-LYF"/>
@@ -61,25 +58,6 @@
                 </subviews>
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
-            <constraints>
-                <constraint firstAttribute="trailing" secondItem="Ne7-SF-c0Q" secondAttribute="trailing" constant="51" id="1Lv-DQ-Pa4"/>
-                <constraint firstItem="Ne7-SF-c0Q" firstAttribute="leading" secondItem="ZTg-uK-7eu" secondAttribute="leading" constant="20" id="2Ed-3s-3Ew"/>
-                <constraint firstAttribute="bottom" secondItem="BeV-Tu-p6V" secondAttribute="bottom" constant="5" id="2w0-lg-Xqx"/>
-                <constraint firstItem="BeV-Tu-p6V" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" symbolic="YES" id="4hn-6h-899"/>
-                <constraint firstItem="q9F-pn-4B5" firstAttribute="centerY" secondItem="op5-ox-cAC" secondAttribute="centerY" constant="1.0000000000000142" id="BVR-eP-OD9"/>
-                <constraint firstItem="Ne7-SF-c0Q" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="7" id="N8A-S7-kDA"/>
-                <constraint firstItem="q9F-pn-4B5" firstAttribute="baseline" secondItem="op5-ox-cAC" secondAttribute="baseline" constant="1.0000000000000142" id="O6X-CM-zeF"/>
-                <constraint firstItem="Ne7-SF-c0Q" firstAttribute="leading" secondItem="q9F-pn-4B5" secondAttribute="leading" id="OMj-08-fye"/>
-                <constraint firstAttribute="trailing" secondItem="BeV-Tu-p6V" secondAttribute="trailing" symbolic="YES" id="Qrm-af-Ma5"/>
-                <constraint firstItem="Ne7-SF-c0Q" firstAttribute="leading" secondItem="bOe-il-Mrh" secondAttribute="leading" id="lcD-5G-B1l"/>
-                <constraint firstItem="ZTg-uK-7eu" firstAttribute="trailing" secondItem="op5-ox-cAC" secondAttribute="trailing" id="mAk-a8-83B"/>
-                <constraint firstItem="bOe-il-Mrh" firstAttribute="trailing" secondItem="op5-ox-cAC" secondAttribute="trailing" constant="-1" id="mtD-nf-uGI"/>
-                <constraint firstItem="bOe-il-Mrh" firstAttribute="leading" secondItem="ZTg-uK-7eu" secondAttribute="leading" constant="20" id="oq2-1Z-PME"/>
-                <constraint firstItem="op5-ox-cAC" firstAttribute="leading" secondItem="q9F-pn-4B5" secondAttribute="trailing" constant="6" id="qKJ-q8-AHz"/>
-                <constraint firstItem="q9F-pn-4B5" firstAttribute="top" secondItem="bOe-il-Mrh" secondAttribute="bottom" constant="3" id="qk6-7B-LS0"/>
-                <constraint firstAttribute="trailing" secondItem="bOe-il-Mrh" secondAttribute="trailing" constant="1" id="rsC-yR-Rf9"/>
-                <constraint firstItem="bOe-il-Mrh" firstAttribute="top" secondItem="Ne7-SF-c0Q" secondAttribute="bottom" constant="3" id="xKe-lT-oKF"/>
-            </constraints>
             <size key="customSize" width="383" height="126"/>
             <connections>
                 <outlet property="contents" destination="bOe-il-Mrh" id="B57-tv-LSO"/>

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.xib
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.xib
@@ -38,12 +38,10 @@
                         <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" ambiguous="YES" image="signpost.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="q9F-pn-4B5">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" fixedFrame="YES" image="signpost.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="q9F-pn-4B5">
                         <rect key="frame" x="285" y="68.333333333333314" width="28" height="19.666666666666671"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="28" id="Bi7-Qv-LqL"/>
-                        </constraints>
                     </imageView>
                     <stackView opaque="NO" contentMode="scaleAspectFit" ambiguous="YES" distribution="equalSpacing" spacing="10" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BeV-Tu-p6V">
                         <rect key="frame" x="0.0" y="87" width="393" height="39"/>

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.xib
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.xib
@@ -43,11 +43,9 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </imageView>
-                    <stackView opaque="NO" contentMode="scaleAspectFit" ambiguous="YES" distribution="equalSpacing" spacing="10" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BeV-Tu-p6V">
+                    <stackView opaque="NO" contentMode="scaleAspectFit" fixedFrame="YES" distribution="equalSpacing" spacing="10" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BeV-Tu-p6V">
                         <rect key="frame" x="0.0" y="87" width="393" height="39"/>
-                        <constraints>
-                            <constraint firstAttribute="width" secondItem="BeV-Tu-p6V" secondAttribute="height" multiplier="353:35" id="SpP-Ym-LYF"/>
-                        </constraints>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     </stackView>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" fixedFrame="YES" image="chevron.forward" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="n3w-IR-4Ta" customClass="SubIconView" customModule="issue_tracker" customModuleProvider="target">
                         <rect key="frame" x="367" y="13" width="13" height="21"/>

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.xib
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewCell.xib
@@ -60,6 +60,7 @@
                 <outlet property="labelsStackView" destination="BeV-Tu-p6V" id="XTm-1I-iIi"/>
                 <outlet property="milestone" destination="op5-ox-cAC" id="8u1-pz-uMu"/>
                 <outlet property="milestoneImage" destination="q9F-pn-4B5" id="tk7-tF-fah"/>
+                <outlet property="subIconView" destination="n3w-IR-4Ta" id="gHH-Lx-Jso"/>
                 <outlet property="title" destination="Ne7-SF-c0Q" id="KUH-ZJ-Kv2"/>
             </connections>
             <point key="canvasLocation" x="-11.450381679389313" y="1.7605633802816902"/>

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewHeaderCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewHeaderCell.swift
@@ -17,9 +17,29 @@ class IssueCollectionViewHeaderCell: UICollectionReusableView {
     override func awakeFromNib() {
         super.awakeFromNib()
         setTitle()
+        setSearchBar()
+    }
+    
+    private func setSearchBar() {
+        searchBar.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            searchBar.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            searchBar.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            searchBar.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            searchBar.heightAnchor.constraint(equalToConstant:  self.frame.height / 2.5)
+        ])
     }
     
     private func setTitle() {
         title.font = UIFont.systemFont(ofSize: safeAreaLayoutGuide.owningView!.frame.height * 0.35, weight: .bold)
+        
+        title.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            title.topAnchor.constraint(equalTo: self.topAnchor),
+            title.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: self.frame.width * 14 / 343),
+            title.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            title.heightAnchor.constraint(equalToConstant: self.frame.height / 2)
+        ])
     }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewHeaderCell.xib
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueCollectionViewHeaderCell.xib
@@ -14,32 +14,20 @@
             <rect key="frame" x="0.0" y="0.0" width="393" height="113"/>
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
-                <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="GM0-g7-soW">
-                    <rect key="frame" x="0.0" y="57" width="393" height="56"/>
-                    <textInputTraits key="textInputTraits"/>
-                </searchBar>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이슈" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q5p-12-QF4">
-                    <rect key="frame" x="16" y="0.0" width="377" height="57"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="57" id="Dpf-u5-cql"/>
-                        <constraint firstAttribute="width" constant="377" id="rwh-Af-ICh"/>
-                    </constraints>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="이슈" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q5p-12-QF4">
+                    <rect key="frame" x="16" y="0.0" width="377" height="33.333333333333336"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <fontDescription key="fontDescription" name=".AppleSDGothicNeoI-Regular" family=".Apple SD Gothic NeoI" pointSize="30"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <searchBar contentMode="redraw" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GM0-g7-soW">
+                    <rect key="frame" x="0.0" y="57" width="393" height="56"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <textInputTraits key="textInputTraits"/>
+                </searchBar>
             </subviews>
             <viewLayoutGuide key="safeArea" id="VXr-Tz-HHm"/>
-            <constraints>
-                <constraint firstItem="GM0-g7-soW" firstAttribute="top" secondItem="q5p-12-QF4" secondAttribute="bottom" id="6w8-Ji-XbE"/>
-                <constraint firstItem="GM0-g7-soW" firstAttribute="width" secondItem="U6b-Vx-4bR" secondAttribute="width" id="AkB-uZ-Ga7"/>
-                <constraint firstItem="q5p-12-QF4" firstAttribute="leading" secondItem="VXr-Tz-HHm" secondAttribute="leading" constant="16" id="Jnw-ar-FjN"/>
-                <constraint firstItem="VXr-Tz-HHm" firstAttribute="trailing" secondItem="q5p-12-QF4" secondAttribute="trailing" id="M0q-Dx-jKS"/>
-                <constraint firstItem="GM0-g7-soW" firstAttribute="centerX" secondItem="VXr-Tz-HHm" secondAttribute="centerX" id="UVC-Lc-1tI"/>
-                <constraint firstItem="GM0-g7-soW" firstAttribute="width" secondItem="U6b-Vx-4bR" secondAttribute="height" multiplier="393:113" id="fCo-pN-Him"/>
-                <constraint firstItem="q5p-12-QF4" firstAttribute="top" secondItem="U6b-Vx-4bR" secondAttribute="top" id="ka8-7N-vL6"/>
-                <constraint firstAttribute="bottom" secondItem="GM0-g7-soW" secondAttribute="bottom" id="zzo-Os-SiE"/>
-            </constraints>
             <connections>
                 <outlet property="searchBar" destination="GM0-g7-soW" id="oz2-S4-or3"/>
                 <outlet property="title" destination="q5p-12-QF4" id="3NF-8L-LT9"/>

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueFilterTableViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueFilterTableViewCell.swift
@@ -11,7 +11,11 @@ class IssueFilterTableViewCell: UITableViewCell {
 
     @IBOutlet var filterOptionLabel: UILabel!
     @IBOutlet var togglableImageView: UIImageView!
-    var isOptionSelected = false
+    var isOptionSelected = false {
+        willSet {
+            togglableImageView.image = newValue ? selectedImage : deselectedImage
+        }
+    }
     var selectedImage: UIImage?
     var deselectedImage: UIImage?
     
@@ -26,8 +30,7 @@ class IssueFilterTableViewCell: UITableViewCell {
         togglableImageView.image = deselectedImage
     }
     
-    func toggleImage() {
+    func toggleSelecting() {
         isOptionSelected.toggle()
-        togglableImageView.image = isOptionSelected ? selectedImage : deselectedImage
     }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueFilterTableViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueFilterTableViewCell.swift
@@ -11,6 +11,7 @@ class IssueFilterTableViewCell: UITableViewCell {
 
     @IBOutlet var filterOptionLabel: UILabel!
     @IBOutlet var togglableImageView: UIImageView!
+    var filterOption: FilterOption?
     var isOptionSelected = false {
         willSet {
             togglableImageView.image = newValue ? selectedImage : deselectedImage
@@ -23,8 +24,8 @@ class IssueFilterTableViewCell: UITableViewCell {
         super.awakeFromNib()
     }
     
-    func configureWith(optionName: String, selectedImage: UIImage?, deselectedImage: UIImage?) {
-        filterOptionLabel.text = optionName
+    func configureWith(filterOption: FilterOption, selectedImage: UIImage?, deselectedImage: UIImage?) {
+        filterOptionLabel.text = filterOption.filterLabel
         self.selectedImage = selectedImage
         self.deselectedImage = deselectedImage
         togglableImageView.image = deselectedImage

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueFilterTableViewCell.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueFilterTableViewCell.swift
@@ -28,7 +28,7 @@ class IssueFilterTableViewCell: UITableViewCell {
         filterOptionLabel.text = filterOption.filterLabel
         self.selectedImage = selectedImage
         self.deselectedImage = deselectedImage
-        togglableImageView.image = deselectedImage
+        isOptionSelected = filterOption.isSelected
     }
     
     func toggleSelecting() {

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueSelectingToolbar.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueSelectingToolbar.swift
@@ -30,7 +30,14 @@ class IssueSelectingToolbar: UIToolbar {
         titleItem.isEnabled = false
         leftItem = UIBarButtonItem(image: UIImage(systemName: "checkmark.circle"), style: .plain, target: nil, action: nil)
         
-        return([leftItem!, flexibleSpace, titleItem, flexibleSpace, rightItem!])
+        guard let rightItem = self.rightItem else {
+            return []
+        }
+        guard let leftItem = self.leftItem else {
+            return []
+        }
+        
+        return([leftItem, flexibleSpace, titleItem, flexibleSpace, rightItem])
     }
     
     func updateTitle(isPlus: Bool) {
@@ -54,7 +61,14 @@ class IssueSelectingToolbar: UIToolbar {
             titleItem.isEnabled = false
         }
         
-        self.setItems([leftItem!, flexibleSpace, titleItem, flexibleSpace, rightItem!], animated: true)
+        guard let rightItem = self.rightItem else {
+            return
+        }
+        guard let leftItem = self.leftItem else {
+            return
+        }
+        
+        self.setItems([leftItem, flexibleSpace, titleItem, flexibleSpace, rightItem], animated: true)
     }
     
     private func setToolBarProPerties() {

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueSelectingToolbar.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueSelectingToolbar.swift
@@ -1,0 +1,37 @@
+//
+//  IssueSelectingToolbar.swift
+//  issue-tracker
+//
+//  Created by SONG on 2023/05/24.
+//
+
+import UIKit
+
+class IssueSelectingToolbar: UIToolbar {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setToolBarProPerties()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setToolBarProPerties()
+    }
+    
+    private func setToolBarItems() -> [UIBarButtonItem] {
+        let rightItem = UIBarButtonItem(image: UIImage(systemName: "archivebox"), style: .plain, target: nil, action: nil)
+        //TODO: 이슈 선택 개수에 따라 title 변경 기능
+        let titleItem = UIBarButtonItem(title: "이슈를 선택하세요.", style: .done, target: nil, action: nil)
+        let leftItem = UIBarButtonItem(image: UIImage(systemName: "checkmark.circle"), style: .plain, target: nil, action: nil)
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        titleItem.isEnabled = false
+        
+        return([leftItem, flexibleSpace, titleItem, flexibleSpace, rightItem])
+    }
+    
+    private func setToolBarProPerties() {
+        self.items = setToolBarItems()
+        self.isHidden = true
+        self.barTintColor = .white
+    }
+}

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueSelectingToolbar.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/IssueSelectingToolbar.swift
@@ -8,6 +8,12 @@
 import UIKit
 
 class IssueSelectingToolbar: UIToolbar {
+    private var selectedCellCount = 0
+    private var rightItem: UIBarButtonItem? = nil
+    private var leftItem: UIBarButtonItem? = nil
+    private let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+    private var titleItem = UIBarButtonItem(title: "이슈를 선택하세요.", style: .done, target: nil, action: nil)
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setToolBarProPerties()
@@ -19,14 +25,36 @@ class IssueSelectingToolbar: UIToolbar {
     }
     
     private func setToolBarItems() -> [UIBarButtonItem] {
-        let rightItem = UIBarButtonItem(image: UIImage(systemName: "archivebox"), style: .plain, target: nil, action: nil)
+        rightItem = UIBarButtonItem(image: UIImage(systemName: "archivebox"), style: .plain, target: nil, action: nil)
         //TODO: 이슈 선택 개수에 따라 title 변경 기능
-        let titleItem = UIBarButtonItem(title: "이슈를 선택하세요.", style: .done, target: nil, action: nil)
-        let leftItem = UIBarButtonItem(image: UIImage(systemName: "checkmark.circle"), style: .plain, target: nil, action: nil)
-        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         titleItem.isEnabled = false
+        leftItem = UIBarButtonItem(image: UIImage(systemName: "checkmark.circle"), style: .plain, target: nil, action: nil)
         
-        return([leftItem, flexibleSpace, titleItem, flexibleSpace, rightItem])
+        return([leftItem!, flexibleSpace, titleItem, flexibleSpace, rightItem!])
+    }
+    
+    func updateTitle(isPlus: Bool) {
+        if isPlus == true {
+            self.selectedCellCount += 1
+            self.titleItem.title = "\(self.selectedCellCount)개의 이슈가 선택됨"
+            titleItem.isEnabled = true
+        }
+        else if isPlus == false && self.selectedCellCount > 1 {
+            self.selectedCellCount -= 1
+            self.titleItem.title = "\(self.selectedCellCount)개의 이슈가 선택됨"
+            titleItem.isEnabled = true
+        }
+        else if isPlus == false && self.selectedCellCount == 1 {
+            self.selectedCellCount -= 1
+            self.titleItem.title = "이슈를 선택하세요."
+            titleItem.isEnabled = false
+        }
+        else if isPlus == false && self.selectedCellCount < 1 {
+            self.titleItem.title = "이슈를 선택하세요."
+            titleItem.isEnabled = false
+        }
+        
+        self.setItems([leftItem!, flexibleSpace, titleItem, flexibleSpace, rightItem!], animated: true)
     }
     
     private func setToolBarProPerties() {

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/SubIconView.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/SubIconView.swift
@@ -27,7 +27,6 @@ class SubIconView: UIImageView {
             self.heightAnchor.constraint(equalTo: superview.heightAnchor, multiplier: 16 / 148),
             self.widthAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.7),
             self.centerXAnchor.constraint(equalTo: superview.trailingAnchor, constant: superview.frame.height / -6),
-
             self.centerYAnchor.constraint(equalTo: superview.topAnchor, constant: superview.frame.height / 6)
         ])
     }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/SubIconView.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/SubIconView.swift
@@ -14,14 +14,14 @@ class SubIconView: UIImageView {
         self.image = image?.withTintColor(.gray, renderingMode: .alwaysOriginal)
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        guard let superview = superview else {
-            return
+    func change(isCheckmarked: Bool) {
+        if isCheckmarked == true {
+            self.image = UIImage(systemName: "checkmark.circle.fill")
+            self.image = image?.withTintColor(.tintColor, renderingMode: .alwaysOriginal)
         }
-        
-        self.translatesAutoresizingMaskIntoConstraints = false
-        
-    }
+        else if isCheckmarked == false {
+            self.image = UIImage(systemName: "chevron.forward")
+            self.image = image?.withTintColor(.gray, renderingMode: .alwaysOriginal)
+        }
     }
 }

--- a/iOS/issue-tracker/issue-tracker/Home/Issue/Views/SubIconView.swift
+++ b/iOS/issue-tracker/issue-tracker/Home/Issue/Views/SubIconView.swift
@@ -12,9 +12,8 @@ class SubIconView: UIImageView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         self.image = image?.withTintColor(.gray, renderingMode: .alwaysOriginal)
-        self.layoutSubviews()
     }
-    
+
     override func layoutSubviews() {
         super.layoutSubviews()
         guard let superview = superview else {
@@ -23,26 +22,6 @@ class SubIconView: UIImageView {
         
         self.translatesAutoresizingMaskIntoConstraints = false
         
-        NSLayoutConstraint.activate([
-            self.heightAnchor.constraint(equalTo: superview.heightAnchor, multiplier: 16 / 148),
-            self.widthAnchor.constraint(equalTo: self.heightAnchor, multiplier: 0.7),
-            self.centerXAnchor.constraint(equalTo: superview.trailingAnchor, constant: superview.frame.height / -6),
-            self.centerYAnchor.constraint(equalTo: superview.topAnchor, constant: superview.frame.height / 6)
-        ])
     }
-    
-    override func updateConstraints() {
-        super.updateConstraints()
-        
-        guard let superview = superview else {
-            return
-        }
-        
-        self.translatesAutoresizingMaskIntoConstraints = false
-        
-        NSLayoutConstraint.activate([
-            self.centerXAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.trailingAnchor, constant: superview.frame.height / -6)
-        ])
     }
-   
 }

--- a/iOS/issue-tracker/issue-tracker/Networking/NetworkManager.swift
+++ b/iOS/issue-tracker/issue-tracker/Networking/NetworkManager.swift
@@ -1,0 +1,31 @@
+//
+//  NetworkManager.swift
+//  issue-tracker
+//
+//  Created by 에디 on 2023/05/20.
+//
+
+import Foundation
+
+class NetworkManager {
+    func fetchIssueData(completion: @escaping (Result<IssueFrameHolder, Error>) -> Void) {
+        guard let url = URL(string: "http://3.38.73.117:8080/api-ios/issues") else { return }
+        let request = URLRequest(url: url, timeoutInterval: 3.0)
+        
+        URLSession.shared.dataTask(with: request) { (data, response, error) in
+            if let error = error {
+                completion(.failure(error))
+            }
+            
+            if let data = data {
+                do {
+                    let issueFrames = try JSONDecoder().decode(IssueFrameHolder.self, from: data)
+                    completion(.success(issueFrames))
+                } catch let decodeError {
+                    completion(.failure(decodeError))
+                }
+            }
+        }.resume()
+        
+    }
+}

--- a/iOS/issue-tracker/issue-tracker/Networking/NetworkManager.swift
+++ b/iOS/issue-tracker/issue-tracker/Networking/NetworkManager.swift
@@ -8,6 +8,27 @@
 import Foundation
 
 class NetworkManager {
+    func fetchIssueData(
+        with url: URL,
+        completion: @escaping (Result<IssueFrameHolder, Error>) -> Void) {
+            let request = URLRequest(url: url, timeoutInterval: 3.0)
+            
+            URLSession.shared.dataTask(with: request) { (data, response, error) in
+                if let error = error {
+                    completion(.failure(error))
+                }
+                
+                if let data = data {
+                    do {
+                        let issueFrames = try JSONDecoder().decode(IssueFrameHolder.self, from: data)
+                        completion(.success(issueFrames))
+                    } catch let decodeError {
+                        completion(.failure(decodeError))
+                    }
+                }
+            }.resume()
+    }
+    
     func fetchIssueData(completion: @escaping (Result<IssueFrameHolder, Error>) -> Void) {
         guard let url = URL(string: "http://3.38.73.117:8080/api-ios/issues") else { return }
         let request = URLRequest(url: url, timeoutInterval: 3.0)
@@ -25,7 +46,6 @@ class NetworkManager {
                     completion(.failure(decodeError))
                 }
             }
-        }.resume()
-        
+        }.resume() 
     }
 }


### PR DESCRIPTION
## 주요 작업 내용
- 이슈 목록 조회
  - 이슈 필터창을 여닫을 떼 fetchData가 되도록 viewWillAppear에서 동작하도록 수정
  
- 이슈 필터 기능
  - 취소, 저장버튼 기능 구현 : 저장 버튼 터치시 선택된 필터 옵션 내용 반영
  - 현재 담당자 중복 선택, 열린 닫힌 이슈 중복 선택은 지원되지 않음(서버 관련)
  
- 이슈 선택 기능
  - 이슈 조회 목록 화면에서 이슈를 선택할 수 있도록 구현
  - 하단 바에 선택된 이슈 개수 표시
  
- 이슈 추가 버튼 UI 구현
  - "+" 버튼 UI 구현 

## 고민했던 부분


## 실행화면
![Simulator Screen Recording - iPhone 14 Pro - 2023-05-26 at 13 59 44](https://github.com/codesquad-members-2023/issue-tracker/assets/70703326/43e13b08-0afd-4b99-8de9-d7af0d630bd0)

