### PR TITLE
[Team-01] iOS 4주차 PR입니다.

### DIFF
--- a/iOS/Issue-tracker/Issue-tracker.xcodeproj/project.pbxproj
+++ b/iOS/Issue-tracker/Issue-tracker.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		DB902B772A16AF0F0007BEB9 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB902B762A16AF0F0007BEB9 /* UIFont+Extension.swift */; };
 		DB902B832A16BF540007BEB9 /* FilterTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB902B822A16BF540007BEB9 /* FilterTableViewController.swift */; };
 		DBCF80F72A11D1F8008BED58 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBCF80F62A11D1F5008BED58 /* UIColor+Extension.swift */; };
-		DBFACA962A1F1AA800D60438 /* CustomNaviFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFACA952A1F1AA800D60438 /* CustomNaviFilter.swift */; };
+		DBFACA962A1F1AA800D60438 /* CustomNavigationFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFACA952A1F1AA800D60438 /* CustomNavigationFilter.swift */; };
 		DBFACA982A1F2F2F00D60438 /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFACA972A1F2F2F00D60438 /* PaddingLabel.swift */; };
 		E05346E5DBC8E9DFC642EE57 /* Pods_Issue_tracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B94F74D84E2128C77C308753 /* Pods_Issue_tracker.framework */; };
 /* End PBXBuildFile section */
@@ -58,7 +58,7 @@
 		DB902B762A16AF0F0007BEB9 /* UIFont+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		DB902B822A16BF540007BEB9 /* FilterTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTableViewController.swift; sourceTree = "<group>"; };
 		DBCF80F62A11D1F5008BED58 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
-		DBFACA952A1F1AA800D60438 /* CustomNaviFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNaviFilter.swift; sourceTree = "<group>"; };
+		DBFACA952A1F1AA800D60438 /* CustomNavigationFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationFilter.swift; sourceTree = "<group>"; };
 		DBFACA972A1F2F2F00D60438 /* PaddingLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -174,7 +174,7 @@
 			isa = PBXGroup;
 			children = (
 				DB902B822A16BF540007BEB9 /* FilterTableViewController.swift */,
-				DBFACA952A1F1AA800D60438 /* CustomNaviFilter.swift */,
+				DBFACA952A1F1AA800D60438 /* CustomNavigationFilter.swift */,
 			);
 			path = FilterIssueTable;
 			sourceTree = "<group>";
@@ -312,7 +312,7 @@
 				DB902B832A16BF540007BEB9 /* FilterTableViewController.swift in Sources */,
 				DBCF80F72A11D1F8008BED58 /* UIColor+Extension.swift in Sources */,
 				DB0C2AE32A226C6900D4D0F2 /* IssueData.swift in Sources */,
-				DBFACA962A1F1AA800D60438 /* CustomNaviFilter.swift in Sources */,
+				DBFACA962A1F1AA800D60438 /* CustomNavigationFilter.swift in Sources */,
 				DB0C2AE72A227D5800D4D0F2 /* PrivateURL.swift in Sources */,
 				DB44ABF62A0CA8C9004F3353 /* TabBarViewController.swift in Sources */,
 				DB4C5B912A0B82EC0064C242 /* AppDelegate.swift in Sources */,

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNavigationFilter.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/CustomNavigationFilter.swift
@@ -1,12 +1,12 @@
 import UIKit
 
-protocol CustomNaviDelegate: AnyObject {
+protocol CustomNavigationDelegate: AnyObject {
     func cancelButtonTapped()
     func saveButtonTapped()
 }
 
-class CustomNaviFilter: UIView {
-    weak var delegate: CustomNaviDelegate?
+class CustomNavigationFilter: UIView {
+    weak var delegate: CustomNavigationDelegate?
     
     private lazy var cancelButton: UIButton = {
         let button = UIButton()

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -130,7 +130,7 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
     func saveButtonTapped() {
         //해당하는 데이터를 불러와서 이슈목록에 보여줌 !!!@!@@!@!@@ㅣ떠따ㅓ끼ㅏㅓㅣㅏㄹ 하하하하ㅏ 그리고 마지막에 디스미스 후 이슈리스트 다시 그리기
         
-        var issueUrl = PrivateURL.openIssue
+        var issueUrl = PrivateURL.issue
         var assigneeUrl = ""
         var labelUrl = ""
         var milestoneUrl = ""

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -86,7 +86,7 @@ extension FilterTableViewController: UITableViewDataSource {
         
         cell.textLabel?.text = filterMenu[indexPath.section][indexPath.row]
         cell.accessoryType = .checkmark
-        cell.tintColor = .gray
+        cell.tintColor = .neutralTextWeak
         
         return cell
     }
@@ -117,5 +117,17 @@ extension FilterTableViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 44
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let cell = tableView.cellForRow(at: indexPath)
+        cell?.accessoryType = .checkmark
+        cell?.tintColor = .accentTextPrimary
+    }
+
+    func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        let cell = tableView.cellForRow(at: indexPath)
+        cell?.accessoryType = .checkmark
+        cell?.tintColor = .neutralTextWeak
     }
 }

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -65,30 +65,30 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
     }
     
     func setupData() {
-            let group = DispatchGroup()
-            group.enter()
-            networkManager.performRequest(urlString: PrivateURL.label) { result in
-                switch result {
-                case .success(let labelData):
-                    self.labelArray = labelData
-                case .failure(let error):
-                    print(error.localizedDescription)
-                }
-                group.leave()
+        let group = DispatchGroup()
+        group.enter()
+        networkManager.performRequest(urlString: PrivateURL.label) { result in
+            switch result {
+            case .success(let labelData):
+                self.labelArray = labelData
+            case .failure(let error):
+                print(error.localizedDescription)
             }
-            group.enter()
-            networkManager.performRequest(urlString: PrivateURL.allAssignee) { result in
-                switch result {
-                case .success(let assigneeData):
-                    self.assigneeArray = assigneeData
-                case .failure(let error):
-                    print(error.localizedDescription)
-                }
-                group.leave()
+            group.leave()
+        }
+        group.enter()
+        networkManager.performRequest(urlString: PrivateURL.allAssignee) { result in
+            switch result {
+            case .success(let assigneeData):
+                self.assigneeArray = assigneeData
+            case .failure(let error):
+                print(error.localizedDescription)
             }
-            group.notify(queue: .main) {
-                self.tableView.reloadData()
-            }
+            group.leave()
+        }
+        group.notify(queue: .main) {
+            self.tableView.reloadData()
+        }
     }
     
     func cancelButtonTapped() {
@@ -125,21 +125,21 @@ extension FilterTableViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: self.filterListCellIdentifier, for: indexPath)
         
         switch indexPath.section {
-                case 0:
-                    cell.textLabel?.text = status[indexPath.row]
-                case 1:
-                    cell.textLabel?.text = (assigneeArray as? [AssigneeList.Assignee])?[indexPath.row].name
-                case 2:
-                    cell.textLabel?.text = (labelArray as? [LabelList.Label])?[indexPath.row].title
-                default:
-                    break
-                }
-                
-                cell.accessoryType = .checkmark
-                cell.tintColor = .neutralTextWeak
-                
-                return cell
-            }
+        case 0:
+            cell.textLabel?.text = status[indexPath.row]
+        case 1:
+            cell.textLabel?.text = (assigneeArray as? [AssigneeList.Assignee])?[indexPath.row].name
+        case 2:
+            cell.textLabel?.text = (labelArray as? [LabelList.Label])?[indexPath.row].title
+        default:
+            break
+        }
+        
+        cell.accessoryType = .checkmark
+        cell.tintColor = .neutralTextWeak
+        
+        return cell
+    }
     
 }
 extension FilterTableViewController: UITableViewDelegate {
@@ -173,11 +173,16 @@ extension FilterTableViewController: UITableViewDelegate {
         let cell = tableView.cellForRow(at: indexPath)
         cell?.accessoryType = .checkmark
         cell?.tintColor = .accentTextPrimary
-    }
-    
-    func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
-        let cell = tableView.cellForRow(at: indexPath)
-        cell?.accessoryType = .checkmark
-        cell?.tintColor = .neutralTextWeak
+        
+        let section = indexPath.section
+        let rows = tableView.numberOfRows(inSection: section)
+        
+        for row in 0..<rows {
+            if let currentCell = tableView.cellForRow(at: IndexPath(row: row, section: section)) {
+                if currentCell != cell && currentCell.tintColor == .accentTextPrimary {
+                    currentCell.tintColor = .neutralTextWeak
+                }
+            }
+        }
     }
 }

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -7,8 +7,8 @@
 
 import UIKit
 
-class FilterTableViewController: UIViewController, CustomNaviDelegate {
-    private let customView = CustomNaviFilter()
+class FilterTableViewController: UIViewController, CustomNavigationDelegate {
+    private let customView = CustomNavigationFilter()
     private let tableView = UITableView()
     
     private let sectionKind = ["상태", "담당자", "레이블"]

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -65,28 +65,30 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
     }
     
     func setupData() {
-        networkManager.performRequest(urlString: PrivateURL.label) { result in
-            switch result {
-            case .success(let assigneeData):
-                self.assigneeArray = assigneeData// 담당자 섹션의 데이터 업데이트
-                DispatchQueue.main.async {
-                    self.tableView.reloadData()
+            let group = DispatchGroup()
+            group.enter()
+            networkManager.performRequest(urlString: PrivateURL.label) { result in
+                switch result {
+                case .success(let labelData):
+                    self.labelArray = labelData
+                case .failure(let error):
+                    print(error.localizedDescription)
                 }
-            case .failure(let error):
-                print(error.localizedDescription)
+                group.leave()
             }
-        }
-        networkManager.performRequest(urlString: PrivateURL.allAssignee) { result in
-            switch result {
-            case .success(let labelData):
-                self.labelArray = labelData// 담당자 섹션의 데이터 업데이트
-                DispatchQueue.main.async {
-                    self.tableView.reloadData()
+            group.enter()
+            networkManager.performRequest(urlString: PrivateURL.allAssignee) { result in
+                switch result {
+                case .success(let assigneeData):
+                    self.assigneeArray = assigneeData
+                case .failure(let error):
+                    print(error.localizedDescription)
                 }
-            case .failure(let error):
-                print(error.localizedDescription)
+                group.leave()
             }
-        }
+            group.notify(queue: .main) {
+                self.tableView.reloadData()
+            }
     }
     
     func cancelButtonTapped() {

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -12,14 +12,12 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
     private let customView = CustomNavigationFilter()
     private let tableView = UITableView()
     
-    private let sectionKind = ["상태", "담당자", "레이블"]
+    private let sectionKind = ["상태", "담당자", "레이블", "마일스톤", "작성자"]
     private let status = ["열린 이슈", "닫힌 이슈"]
     private var assigneeArray: [APIData] = []
     private var labelArray: [APIData] = []
     private var milestoneArray: [APIData] = []
     private var writerArray: [APIData] = []
-    
-    
     
     private let filterListCellIdentifier = "filterListCell"
     private let filterListHeaderIdentifier = "filterListHeader"
@@ -79,6 +77,7 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
             }
             group.leave()
         }
+        
         group.enter()
         networkManager.performRequest(searchTerm: PrivateURL.allAssignee) { result in
             switch result {
@@ -89,10 +88,34 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
             }
             group.leave()
         }
+        
+        group.enter()
+        networkManager.performRequest(searchTerm: PrivateURL.milestone) { result in
+            switch result {
+            case .success(let milestoneData):
+                self.milestoneArray = milestoneData
+            case .failure(let error):
+                print(error.localizedDescription)
+            }
+            group.leave()
+        }
+        
+        group.enter()
+        networkManager.performRequest(searchTerm: PrivateURL.writer) { result in
+            switch result {
+            case .success(let writerData):
+                self.writerArray = writerData
+            case .failure(let error):
+                print(error.localizedDescription)
+            }
+            group.leave()
+        }
+        
         group.notify(queue: .main) {
             self.tableView.reloadData()
         }
     }
+    
     
     func cancelButtonTapped() {
         self.dismiss(animated: true)
@@ -117,13 +140,16 @@ extension FilterTableViewController: UITableViewDataSource {
             return assigneeArray.count
         case 2:
             return labelArray.count
+        case 3:
+            return milestoneArray.count
+        case 4:
+            return writerArray.count
+            
         default:
             return 0
         }
     }
-    //(assigneeArray as? [AllAssignee.Assignee])?[indexPath.row].name
-    //(labelArray as? [LabelList.Label])?[indexPath.row].title
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: self.filterListCellIdentifier, for: indexPath)
         
@@ -134,6 +160,10 @@ extension FilterTableViewController: UITableViewDataSource {
             cell.textLabel?.text = (assigneeArray as? [AssigneeList.Assignee])?[indexPath.row].name
         case 2:
             cell.textLabel?.text = (labelArray as? [LabelList.Label])?[indexPath.row].title
+        case 3:
+            cell.textLabel?.text = (milestoneArray as? [MilestoneList.Milestone])?[indexPath.row].title
+        case 4:
+            cell.textLabel?.text = (writerArray as? [WriterList.Writer])?[indexPath.row].name
         default:
             break
         }

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -67,7 +67,7 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
     func setupData() {
         let group = DispatchGroup()
         group.enter()
-        networkManager.performRequest(urlString: PrivateURL.label) { result in
+        networkManager.performRequest(searchTerm: PrivateURL.openIssue) { result in
             switch result {
             case .success(let labelData):
                 self.labelArray = labelData
@@ -77,7 +77,7 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
             group.leave()
         }
         group.enter()
-        networkManager.performRequest(urlString: PrivateURL.allAssignee) { result in
+        networkManager.performRequest(searchTerm: PrivateURL.allAssignee) { result in
             switch result {
             case .success(let assigneeData):
                 self.assigneeArray = assigneeData

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -128,9 +128,10 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
     }
     
     func saveButtonTapped() {
-        //해당하는 데이터를 불러와서 이슈목록에 보여줌 !!!@!@@!@!@@ㅣ떠따ㅓ끼ㅏㅓㅣㅏㄹ 하하하하ㅏ 그리고 마지막에 디스미스 후 이슈리스트 다시 그리기
-        
-        var issueUrl = PrivateURL.issue
+//        api수정되면 주석처리된 코드로 해야함
+//        var issueUrl = PrivateURL.issue
+        //현재코드는 임의로 오픈클로즈이슈 아무것도 선택하지 않았을때 open이슈대상으로 보여주는코드
+        var issueUrl = PrivateURL.openIssue
         var assigneeUrl = ""
         var labelUrl = ""
         var milestoneUrl = ""

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -67,7 +67,7 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
     }
     
     func saveButtonTapped() {
-        print("저장은 추후 구현")
+        //TODO: 추후 구현
     }
 }
 

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -153,6 +153,8 @@ extension FilterTableViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: self.filterListCellIdentifier, for: indexPath)
         
+        cell.selectionStyle = UITableViewCell.SelectionStyle.none
+        
         switch indexPath.section {
         case 0:
             cell.textLabel?.text = status[indexPath.row]
@@ -221,5 +223,7 @@ extension FilterTableViewController: UITableViewDelegate {
                 }
             }
         }
+        //클릭하기 쉽도록 스크롤 컨트롤
+        tableView.selectRow(at: indexPath, animated: true, scrollPosition: .middle)
     }
 }

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -7,7 +7,13 @@
 
 import UIKit
 
+protocol UploadData: AnyObject {
+    func uploadIssue(url: String)
+}
+
 class FilterTableViewController: UIViewController, CustomNavigationDelegate {
+    weak var delegate: UploadData?
+    
     private let networkManager = NetworkManager.shared
     private let customView = CustomNavigationFilter()
     private let tableView = UITableView()
@@ -27,7 +33,7 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
         tableView.dataSource = self
         tableView.delegate = self
         customView.delegate = self
-        
+       
         customViewLayout()
         tableViewLayout()
         setupData()
@@ -122,7 +128,48 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
     }
     
     func saveButtonTapped() {
-        //TODO: 추후 구현
+        //해당하는 데이터를 불러와서 이슈목록에 보여줌 !!!@!@@!@!@@ㅣ떠따ㅓ끼ㅏㅓㅣㅏㄹ 하하하하ㅏ 그리고 마지막에 디스미스 후 이슈리스트 다시 그리기
+        
+        var issueUrl = PrivateURL.openIssue
+        var assigneeUrl = ""
+        var labelUrl = ""
+        var milestoneUrl = ""
+        var writeUrl = ""
+        var selectedRows: [IndexPath] = []
+           
+           for section in 0..<sectionKind.count {
+               let rows = tableView.numberOfRows(inSection: section)
+               for row in 0..<rows {
+                   let indexPath = IndexPath(row: row, section: section)
+                   if let cell = tableView.cellForRow(at: indexPath), cell.tintColor == .accentTextPrimary {
+                       selectedRows.append(indexPath)
+                   }
+               }
+           }
+
+        
+        for item in selectedRows {
+            switch item.first {
+            case 0:
+                if item.last == 0 {
+                    issueUrl = PrivateURL.openIssue
+                }else {
+                    issueUrl = PrivateURL.closedIssue
+                }
+            case 1:
+                assigneeUrl = "&assignees=\((item.last ?? 0) + 1)"
+            case 2:
+                labelUrl = "&labels=\((item.last ?? 0) + 1)"
+            case 3:
+                milestoneUrl = "&milestones=\((item.last ?? 0) + 1)"
+            case 4:
+                writeUrl = "&writers=\((item.last ?? 0) + 1)"
+            default:
+                break
+            }
+        }
+        dismiss(animated: true)
+        delegate?.uploadIssue(url: issueUrl + assigneeUrl + labelUrl + milestoneUrl + writeUrl)
     }
 }
 

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -204,9 +204,13 @@ extension FilterTableViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let cell = tableView.cellForRow(at: indexPath)
-        cell?.accessoryType = .checkmark
-        cell?.tintColor = .accentTextPrimary
-        
+        // 토글형식
+        if cell?.tintColor == .accentTextPrimary{
+            cell?.tintColor = .neutralTextWeak
+        }else{
+            cell?.tintColor = .accentTextPrimary
+        }
+        // 섹션마다 단일선택
         let section = indexPath.section
         let rows = tableView.numberOfRows(inSection: section)
         

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -85,11 +85,10 @@ extension FilterTableViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: self.filterListCellIdentifier, for: indexPath)
         
         cell.textLabel?.text = filterMenu[indexPath.section][indexPath.row]
-        let image = UIImage(systemName: "checkmark")
-        cell.accessoryView = UIImageView(image: image)
+        cell.accessoryType = .checkmark
+        cell.tintColor = .gray
         
         return cell
-        
     }
     
 }

--- a/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/FilterIssueTable/FilterTableViewController.swift
@@ -16,6 +16,9 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
     private let status = ["열린 이슈", "닫힌 이슈"]
     private var assigneeArray: [APIData] = []
     private var labelArray: [APIData] = []
+    private var milestoneArray: [APIData] = []
+    private var writerArray: [APIData] = []
+    
     
     
     private let filterListCellIdentifier = "filterListCell"
@@ -67,7 +70,7 @@ class FilterTableViewController: UIViewController, CustomNavigationDelegate {
     func setupData() {
         let group = DispatchGroup()
         group.enter()
-        networkManager.performRequest(searchTerm: PrivateURL.openIssue) { result in
+        networkManager.performRequest(searchTerm: PrivateURL.label) { result in
             switch result {
             case .success(let labelData):
                 self.labelArray = labelData

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/CollectionHeaderView.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/CollectionHeaderView.swift
@@ -8,9 +8,10 @@ protocol CustomViewDelegate: AnyObject {
     func buttonTapped()
 }
 
+
 import UIKit
 
-class CollectionHeaderView: UICollectionReusableView {
+class CollectionHeaderView: UICollectionReusableView, UISearchBarDelegate {
     weak var delegate: CustomViewDelegate?
     static let identifier = "IssueHeader"
     
@@ -20,6 +21,11 @@ class CollectionHeaderView: UICollectionReusableView {
         label.font = UIFont.semiBoldXXL
         label.textColor = .neutralTextStrong
         return label
+    }()
+    
+    private let searchBar: UISearchBar = {
+        let searchBar = UISearchBar()
+        return searchBar
     }()
     
     private let filterButton: UIButton = {
@@ -42,10 +48,15 @@ class CollectionHeaderView: UICollectionReusableView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        [titleLabel, filterButton, choiceButton].forEach {
+        [titleLabel, filterButton, choiceButton, searchBar].forEach {
             addSubview($0)
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
+        
+        searchBar.delegate = self
+        addSubview(searchBar)
+        searchBar.translatesAutoresizingMaskIntoConstraints = false
+        
         layout()
     }
     
@@ -53,6 +64,7 @@ class CollectionHeaderView: UICollectionReusableView {
         setFilterButtonConstraint()
         setChioceButtonConstraint()
         setTitleLabelConstraint()
+        searchBarConstraint()
         self.backgroundColor = UIColor.neutralBackground
     }
     func setFilterButtonConstraint() {
@@ -60,7 +72,7 @@ class CollectionHeaderView: UICollectionReusableView {
             filterButton.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
             filterButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -325),
             filterButton.topAnchor.constraint(equalTo: self.topAnchor, constant: 0),
-            filterButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -62)
+            filterButton.heightAnchor.constraint(equalToConstant: 32)
         ])
     }
     
@@ -69,18 +81,29 @@ class CollectionHeaderView: UICollectionReusableView {
             choiceButton.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 325),
             choiceButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16),
             choiceButton.topAnchor.constraint(equalTo: self.topAnchor, constant: 0),
-            choiceButton.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -62)
+            choiceButton.heightAnchor.constraint(equalToConstant: 32)
         ])
     }
     
     func setTitleLabelConstraint() {
         NSLayoutConstraint.activate([
             titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
-            titleLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0),
+            titleLabel.bottomAnchor.constraint(equalTo: searchBar.topAnchor, constant: 0),
             titleLabel.heightAnchor.constraint(equalToConstant: 48),
             titleLabel.widthAnchor.constraint(equalToConstant: 59)
         ])
     }
+    
+    func searchBarConstraint() {
+        NSLayoutConstraint.activate([
+            searchBar.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 16),
+            searchBar.heightAnchor.constraint(equalToConstant: 48),
+            searchBar.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0),
+            searchBar.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16)
+        ])
+    }
+    
+    
     
     @objc private func buttonTapped() {
         delegate?.buttonTapped()

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueCell.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueCell.swift
@@ -88,6 +88,11 @@ class IssueCell: UICollectionViewCell {
         }
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        tagLabelStackView.arrangedSubviews.forEach { view in view.removeFromSuperview() }
+      }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueCell.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueCell.swift
@@ -62,7 +62,7 @@ class IssueCell: UICollectionViewCell {
         return stackView
     }()
     
-    func makeLabel(labels: [Label]) {
+    func makeLabel(labels: [IssueList.Label]) {
         for label in labels {
             var tagLabel: UILabel = {
                 let tags = PaddingLabel(withInsets: 4, 4, 16, 16)

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -96,7 +96,7 @@ extension IssueListCollectionViewController: UICollectionViewDataSource {
         cell?.backgroundColor = UIColor.neutralBackground
         
         cell?.titleLabel.text = (issueArrays as? [IssueList.Issue])?[indexPath.row].title
-        cell?.descriptionLabel.text = (issueArrays as? [IssueList.Issue])?[indexPath.row].issueDescription
+        cell?.descriptionLabel.text = (issueArrays as? [IssueList.Issue])?[indexPath.row].description
         //마일스톤
         let attributedString = NSMutableAttributedString(string: "")
         let imageAttachment = NSTextAttachment()

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -47,7 +47,7 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
         collectionView.delegate = self
         collectionView.dataSource = self
         collectionView.backgroundColor = UIColor.neutralBackgroundStrong
-
+        
         collectionView.register(IssueCell.self, forCellWithReuseIdentifier: IssueCell.identifier)
         collectionView.register(CollectionHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: CollectionHeaderView.identifier)
         self.view.addSubview(collectionView)
@@ -70,22 +70,15 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
     
     func buttonTapped() {
         self.present(filterViewController, animated: true, completion: nil)
-        }
+    }
     
     func changeStatusBarBgColor(bgColor: UIColor?) {
-            if #available(iOS 13.0, *) {
-                let window = UIApplication.shared.windows.first
-                let statusBarManager = window?.windowScene?.statusBarManager
-                
-                let statusBarView = UIView(frame: statusBarManager?.statusBarFrame ?? .zero)
-                statusBarView.backgroundColor = bgColor
-                
-                window?.addSubview(statusBarView)
-            } else {
-                let statusBarView = UIApplication.shared.value(forKey: "statusBar") as? UIView
-                statusBarView?.backgroundColor = bgColor
-            }
-        }
+        let window = UIApplication.shared.windows.first
+        let statusBarManager = window?.windowScene?.statusBarManager
+        let statusBarView = UIView(frame: statusBarManager?.statusBarFrame ?? .zero)
+        statusBarView.backgroundColor = bgColor
+        window?.addSubview(statusBarView)
+    }
 }
 
 extension IssueListCollectionViewController: UICollectionViewDataSource {
@@ -99,9 +92,9 @@ extension IssueListCollectionViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: IssueCell.identifier, for: indexPath) as? IssueCell
-      
+        
         cell?.backgroundColor = UIColor.neutralBackground
-
+        
         cell?.titleLabel.text = issueArrays[indexPath.row].title
         cell?.descriptionLabel.text = "두줄까지 가능 ~"
         //마일스톤
@@ -119,10 +112,10 @@ extension IssueListCollectionViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         
         guard let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: CollectionHeaderView.identifier, for: indexPath)
-        as? CollectionHeaderView else {return UICollectionReusableView()}
+                as? CollectionHeaderView else {return UICollectionReusableView()}
         headerView.delegate = self
         return headerView
-        }
+    }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         let width = self.view.frame.width
@@ -143,7 +136,7 @@ extension IssueListCollectionViewController: UICollectionViewDelegateFlowLayout 
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-            let sectionInsets = UIEdgeInsets(top: 2, left: 0, bottom: 0, right: 0)
-            return sectionInsets
-        }
+        let sectionInsets = UIEdgeInsets(top: 2, left: 0, bottom: 0, right: 0)
+        return sectionInsets
+    }
 }

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -96,6 +96,8 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate, U
             }
         }
     }
+    
+    
 }
 
 extension IssueListCollectionViewController: UICollectionViewDataSource {
@@ -136,7 +138,7 @@ extension IssueListCollectionViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         let width = self.view.frame.width
-        let headerRatio: CGFloat = 94/375
+        let headerRatio: CGFloat = 110/321
         
         return CGSize(width: width, height: width * headerRatio)
     }

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -39,9 +39,9 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
         
     }
     override func viewWillAppear(_ animated: Bool) {
-            super.viewWillAppear(animated)
-            changeStatusBarBgColor(bgColor: UIColor.white)
-        }
+        super.viewWillAppear(animated)
+        changeStatusBarBgColor(bgColor: UIColor.white)
+    }
     
     func setUI() {
         collectionView.delegate = self

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -14,7 +14,7 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
     let filterViewController = FilterTableViewController()
     
     let networkManager = NetworkManager.shared
-    var issueArrays: [IssueList.Issue] = []
+    var issueArrays: [APIData] = []
     
     var createIssueButton: UIButton = {
         let button = UIButton()
@@ -95,17 +95,17 @@ extension IssueListCollectionViewController: UICollectionViewDataSource {
         
         cell?.backgroundColor = UIColor.neutralBackground
         
-        cell?.titleLabel.text = issueArrays[indexPath.row].title
-        cell?.descriptionLabel.text = "두줄까지 가능 ~"
+        cell?.titleLabel.text = (issueArrays as? [IssueList.Issue])?[indexPath.row].title
+        cell?.descriptionLabel.text = (issueArrays as? [IssueList.Issue])?[indexPath.row].issueDescription
         //마일스톤
         let attributedString = NSMutableAttributedString(string: "")
         let imageAttachment = NSTextAttachment()
         imageAttachment.image = UIImage(named: TabBarItems.milestone.rawValue)
         attributedString.append(NSAttributedString(attachment: imageAttachment))
-        attributedString.append(NSAttributedString(string: issueArrays[indexPath.row].milestone ?? String()))
+        attributedString.append(NSAttributedString(string: (issueArrays as? [IssueList.Issue])?[indexPath.row].milestone ?? String()))
         cell?.milestones.attributedText = attributedString
         
-        cell?.makeLabel(labels: issueArrays[indexPath.row].labels)
+        cell?.makeLabel(labels: (issueArrays as? [IssueList.Issue])?[indexPath.row].labels ?? [IssueList.Label]())
         return cell ?? UICollectionViewCell()
     }
     

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
+class IssueListCollectionViewController: UIViewController, CustomViewDelegate, UploadData {
     
     var collectionView: UICollectionView!
     let cellRatio: CGFloat = 150/375
@@ -46,6 +46,7 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
     func setUI() {
         collectionView.delegate = self
         collectionView.dataSource = self
+        filterViewController.delegate = self
         collectionView.backgroundColor = UIColor.neutralBackgroundStrong
         
         collectionView.register(IssueCell.self, forCellWithReuseIdentifier: IssueCell.identifier)
@@ -56,6 +57,7 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
     
     func setupData() {
         networkManager.performRequest(searchTerm: PrivateURL.openIssue) { result in
+            print(PrivateURL.openIssue)
             switch result {
             case .success(let issueData):
                 self.issueArrays = issueData
@@ -78,6 +80,21 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
         let statusBarView = UIView(frame: statusBarManager?.statusBarFrame ?? .zero)
         statusBarView.backgroundColor = bgColor
         window?.addSubview(statusBarView)
+    }
+    
+    func uploadIssue(url: String) {
+        print(url)
+        networkManager.performRequest(searchTerm: url) { result in
+            switch result {
+            case .success(let issueData):
+                self.issueArrays = issueData
+                DispatchQueue.main.async {
+                    self.collectionView.reloadData()
+                }
+            case .failure(let error):
+                print(error.localizedDescription)
+            }
+        }
     }
 }
 

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -35,7 +35,7 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
         collectionView = UICollectionView(frame: self.view.frame, collectionViewLayout: layout)
         self.view.backgroundColor = .white
         setUI()
-        setupDatas()
+        setupData()
         
     }
     override func viewWillAppear(_ animated: Bool) {
@@ -54,11 +54,11 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
         self.view.addSubview(createIssueButton)
     }
     
-    func setupDatas() {
+    func setupData() {
         networkManager.performRequest(urlString: PrivateURL.openIssue) { result in
             switch result {
-            case .success(let issueDatas):
-                self.issueArrays = issueDatas
+            case .success(let issueData):
+                self.issueArrays = issueData
                 DispatchQueue.main.async {
                     self.collectionView.reloadData()
                 }

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -14,7 +14,7 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
     let filterViewController = FilterTableViewController()
     
     let networkManager = NetworkManager.shared
-    var issueArrays: [Issue] = []
+    var issueArrays: [IssueList.Issue] = []
     
     var createIssueButton: UIButton = {
         let button = UIButton()

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -55,7 +55,7 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
     }
     
     func setupDatas() {
-        networkManager.fetchIssue(URL: PrivateURL.openIssue) { result in
+        networkManager.performRequest(urlString: PrivateURL.openIssue) { result in
             switch result {
             case .success(let issueDatas):
                 self.issueArrays = issueDatas

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/IssueListCollectionViewController.swift
@@ -55,7 +55,7 @@ class IssueListCollectionViewController: UIViewController, CustomViewDelegate {
     }
     
     func setupData() {
-        networkManager.performRequest(urlString: PrivateURL.openIssue) { result in
+        networkManager.performRequest(searchTerm: PrivateURL.openIssue) { result in
             switch result {
             case .success(let issueData):
                 self.issueArrays = issueData

--- a/iOS/Issue-tracker/Issue-tracker/IssueList/PaddingLabel.swift
+++ b/iOS/Issue-tracker/Issue-tracker/IssueList/PaddingLabel.swift
@@ -20,7 +20,7 @@ class PaddingLabel: UILabel {
         self.leftInset = left
         self.rightInset = right
         super.init(frame: CGRect.zero)
-        layoutSubviews()
+        setNeedsLayout()
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
@@ -24,12 +24,10 @@ struct IssueList {
     }
 }
 struct LabelList {
-    // MARK: - Welcome10
     struct LabelData {
         let labels: [Label]
     }
     
-    // MARK: - Label
     struct Label {
         let id: Int
         let title, labelDescription, bgColorCode, fontColorCode: String

--- a/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
@@ -7,17 +7,31 @@
 
 import Foundation
 
-struct IssueData: Codable {
-    let issues: [Issue]
+struct IssueList {
+    struct IssueData: Codable {
+        let issues: [Issue]
+    }
+    
+    struct Label: Codable {
+        let title: String?
+        let bgColorCode: String?
+    }
+    
+    struct Issue: Codable {
+        let title: String?
+        let labels: [Label]
+        let milestone: String?
+    }
 }
-
-struct Label: Codable {
-    let title: String?
-    let bgColorCode: String?
-}
-
-struct Issue: Codable {
-    let title: String?
-    let labels: [Label]
-    let milestone: String?
+struct LabelList {
+    // MARK: - Welcome10
+    struct LabelData {
+        let labels: [Label]
+    }
+    
+    // MARK: - Label
+    struct Label {
+        let id: Int
+        let title, labelDescription, bgColorCode, fontColorCode: String
+    }
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
@@ -48,11 +48,39 @@ struct AssigneeList {
     struct AssigneeData: Codable {
         let assignees: [Assignee]
     }
-    
-    // MARK: - Assignee
+
     struct Assignee: APIData, Codable {
         let id: Int?
         let name: String?
         let imgURL: String?
+    }
+}
+
+struct MilestoneList {
+    struct MilesoneData {
+        let count: Count
+        let milestones: [Milestone]
+    }
+
+    struct Count {
+        let label, milestone, opened, closed: Int
+    }
+
+    struct Milestone {
+        let id: Int
+        let title, milestoneDescription, dueDate: String
+        let openedIssue, closedIssue: Int
+    }
+}
+
+struct WriterList {
+    struct WriterData {
+        let writers: [Writer]
+    }
+    
+    struct Writer {
+        let id: Int
+        let name: String
+        let imgURL: String
     }
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
@@ -57,30 +57,25 @@ struct AssigneeList {
 }
 
 struct MilestoneList {
-    struct MilesoneData {
-        let count: Count
+    struct MilesoneData: Codable {
         let milestones: [Milestone]
     }
 
-    struct Count {
-        let label, milestone, opened, closed: Int
-    }
-
-    struct Milestone {
-        let id: Int
-        let title, milestoneDescription, dueDate: String
-        let openedIssue, closedIssue: Int
+    struct Milestone: Codable, APIData {
+        let id: Int?
+        let title, milestoneDescription, dueDate: String?
+        let openedIssue, closedIssue: Int?
     }
 }
 
 struct WriterList {
-    struct WriterData {
+    struct WriterData: Codable {
         let writers: [Writer]
     }
     
-    struct Writer {
-        let id: Int
-        let name: String
-        let imgURL: String
+    struct Writer: Codable, APIData {
+        let id: Int?
+        let name: String?
+        let imgURL: String?
     }
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+protocol APIData{
+    
+}
+
 struct IssueList {
     struct IssueData: Codable {
         let issues: [Issue]
@@ -17,10 +21,16 @@ struct IssueList {
         let bgColorCode: String?
     }
     
-    struct Issue: Codable {
-        let title: String?
+    struct Count {
+        let label, milestone, opened, closed: Int?
+    }
+    
+    struct Issue: Codable, APIData {
+        let id: Int?
+        let title, issueDescription, createAt: String?
         let labels: [Label]
-        let milestone: String?
+        let milestone, author: String?
+        let authorURL: String?
     }
 }
 struct LabelList {
@@ -28,8 +38,21 @@ struct LabelList {
         let labels: [Label]
     }
     
-    struct Label {
+    struct Label: APIData {
         let id: Int
         let title, labelDescription, bgColorCode, fontColorCode: String
+    }
+}
+
+struct AllAssignee {
+    struct AssigneeData {
+        let assignees: [Assignee]
+    }
+    
+    // MARK: - Assignee
+    struct Assignee: APIData, Codable {
+        let id: Int
+        let name: String
+        let imgURL: String
     }
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/IssueData.swift
@@ -27,32 +27,32 @@ struct IssueList {
     
     struct Issue: Codable, APIData {
         let id: Int?
-        let title, issueDescription, createAt: String?
+        let title, description, createAt: String?
         let labels: [Label]
         let milestone, author: String?
         let authorURL: String?
     }
 }
 struct LabelList {
-    struct LabelData {
+    struct LabelData: Codable {
         let labels: [Label]
     }
     
-    struct Label: APIData {
-        let id: Int
-        let title, labelDescription, bgColorCode, fontColorCode: String
+    struct Label: APIData, Codable {
+        let id: Int?
+        let title, labelDescription, bgColorCode, fontColorCode: String?
     }
 }
 
-struct AllAssignee {
-    struct AssigneeData {
+struct AssigneeList {
+    struct AssigneeData: Codable {
         let assignees: [Assignee]
     }
     
     // MARK: - Assignee
     struct Assignee: APIData, Codable {
-        let id: Int
-        let name: String
-        let imgURL: String
+        let id: Int?
+        let name: String?
+        let imgURL: String?
     }
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
@@ -17,7 +17,7 @@ final class NetworkManager {
     
     static let shared = NetworkManager()
     private init() {}
-    typealias NetworkCompletion = (Result<[Issue], NetworkError>) -> Void
+    typealias NetworkCompletion = (Result<[IssueList.Issue], NetworkError>) -> Void
     
     func performRequest(urlString: String, completion: @escaping NetworkCompletion) {
         guard let url = URL(string: urlString) else { return }
@@ -43,9 +43,9 @@ final class NetworkManager {
         task.resume()
     }
     
-    private func parseJSON(_ issueData: Data) -> [Issue]? {
+    private func parseJSON(_ issueData: Data) -> [IssueList.Issue]? {
         do {
-            let issueData = try JSONDecoder().decode(IssueData.self, from: issueData)
+            let issueData = try JSONDecoder().decode(IssueList.IssueData.self, from: issueData)
             return issueData.issues
         } catch {
             print(error.localizedDescription)

--- a/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
@@ -19,8 +19,8 @@ final class NetworkManager {
     private init() {}
     typealias NetworkCompletion = (Result<[APIData], NetworkError>) -> Void
     
-    func performRequest(urlString: String, completion: @escaping NetworkCompletion) {
-        guard let url = URL(string: urlString) else { return }
+    func performRequest(searchTerm: String, completion: @escaping NetworkCompletion) {
+        guard let url = URL(string: "\(PrivateURL.url)\(searchTerm)") else { return }
         let session = URLSession(configuration: .default)
         let task = session.dataTask(with: url) { (data, response, error) in
             if error != nil {

--- a/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
@@ -49,10 +49,22 @@ final class NetworkManager {
             
             if let labelData = try? decoder.decode(LabelList.LabelData.self, from: issueData) {
                 return labelData.labels
-            } else if let assigneeData = try? decoder.decode(AssigneeList.AssigneeData.self, from: issueData) {
+            }
+            
+            else if let assigneeData = try? decoder.decode(AssigneeList.AssigneeData.self, from: issueData) {
                 return assigneeData.assignees
-            } else if let issueData = try? decoder.decode(IssueList.IssueData.self, from: issueData) {
+            }
+            
+            else if let issueData = try? decoder.decode(IssueList.IssueData.self, from: issueData) {
                 return issueData.issues
+            }
+            
+            else if let milestoneData = try? decoder.decode(MilestoneList.MilesoneData.self, from: issueData) {
+                return milestoneData.milestones
+            }
+            
+            else if let writerData = try? decoder.decode(WriterList.WriterData.self, from: issueData) {
+                return writerData.writers
             }
             
             return nil

--- a/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
@@ -18,15 +18,8 @@ final class NetworkManager {
     static let shared = NetworkManager()
     private init() {}
     typealias NetworkCompletion = (Result<[Issue], NetworkError>) -> Void
-
-    func fetchIssue(URL: String, completion: @escaping NetworkCompletion) {
-        let urlString = URL
-        performRequest(with: urlString) { result in
-            completion(result)
-        }
-    }
     
-    private func performRequest(with urlString: String, completion: @escaping NetworkCompletion) {
+    func performRequest(urlString: String, completion: @escaping NetworkCompletion) {
         guard let url = URL(string: urlString) else { return }
         let session = URLSession(configuration: .default)
         let task = session.dataTask(with: url) { (data, response, error) in

--- a/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
@@ -17,7 +17,7 @@ final class NetworkManager {
     
     static let shared = NetworkManager()
     private init() {}
-    typealias NetworkCompletion = (Result<[IssueList.Issue], NetworkError>) -> Void
+    typealias NetworkCompletion = (Result<[APIData], NetworkError>) -> Void
     
     func performRequest(urlString: String, completion: @escaping NetworkCompletion) {
         guard let url = URL(string: urlString) else { return }
@@ -32,9 +32,9 @@ final class NetworkManager {
                 return
             }
 
-            if let issues = self.parseJSON(safeData) {
+            if let safeData = self.parseJSON(safeData) {
                 print("Parse 실행")
-                completion(.success(issues))
+                completion(.success(safeData))
             } else {
                 print("Parse 실패")
                 completion(.failure(.parseError))
@@ -43,7 +43,7 @@ final class NetworkManager {
         task.resume()
     }
     
-    private func parseJSON(_ issueData: Data) -> [IssueList.Issue]? {
+    private func parseJSON(_ issueData: Data) -> [APIData]? {
         do {
             let issueData = try JSONDecoder().decode(IssueList.IssueData.self, from: issueData)
             return issueData.issues

--- a/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/NetworkManager.swift
@@ -31,7 +31,7 @@ final class NetworkManager {
                 completion(.failure(.dataError))
                 return
             }
-
+            
             if let safeData = self.parseJSON(safeData) {
                 print("Parse 실행")
                 completion(.success(safeData))
@@ -45,8 +45,17 @@ final class NetworkManager {
     
     private func parseJSON(_ issueData: Data) -> [APIData]? {
         do {
-            let issueData = try JSONDecoder().decode(IssueList.IssueData.self, from: issueData)
-            return issueData.issues
+            let decoder = JSONDecoder()
+            
+            if let labelData = try? decoder.decode(LabelList.LabelData.self, from: issueData) {
+                return labelData.labels
+            } else if let assigneeData = try? decoder.decode(AssigneeList.AssigneeData.self, from: issueData) {
+                return assigneeData.assignees
+            } else if let issueData = try? decoder.decode(IssueList.IssueData.self, from: issueData) {
+                return issueData.issues
+            }
+            
+            return nil
         } catch {
             print(error.localizedDescription)
             return nil

--- a/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct PrivateURL {
     static let url = "http://52.79.159.39:8888/api"
+    static let issue = "/issues"
     static let openIssue = "/issues?isOpen=true"
     static let closedIssue = "/issues?isOpen=false"
     static let allAssignee = "/assignees"

--- a/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
@@ -10,4 +10,5 @@ import Foundation
 struct PrivateURL {
     static let openIssue = "http://52.79.159.39:8888/api/issues?isOpen=true&assignee=1"
     static let allAssignee = "http://52.79.159.39:8888/api/assignees"
+    static let label = "http://52.79.159.39:8888/api/labels"
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct PrivateURL {
-    static let openIssue = "http://52.79.159.39:8888/api/issues?isOpen=true&assignee=1"
+    static let openIssue = "http://52.79.159.39:8888/api/issues?isOpen=true"
     static let allAssignee = "http://52.79.159.39:8888/api/assignees"
     static let label = "http://52.79.159.39:8888/api/labels"
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct PrivateURL {
-    static let url = "http://52.79.159.39:8888/api"
+    static let url = "http://3.37.70.64:8888/api"
     static let issue = "/issues"
     static let openIssue = "/issues?isOpen=true"
     static let closedIssue = "/issues?isOpen=false"

--- a/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 struct PrivateURL {
-    static let openIssue = "http://52.79.159.39:8888/api/issues?status=open"
+    static let openIssue = "http://52.79.159.39:8888/api/issues?isOpen=true&assignee=1"
+    static let allAssignee = "http://52.79.159.39:8888/api/assignees"
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
@@ -13,6 +13,6 @@ struct PrivateURL {
     static let closedIssue = "/issues?isOpen=false"
     static let allAssignee = "/assignees"
     static let label = "/labels"
-    static let milestone = "/milestones?status=open"
+    static let milestone = "/milestones?isOpen=true"
     static let writer = "/writers"
 }

--- a/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
+++ b/iOS/Issue-tracker/Issue-tracker/Network/PrivateURL.swift
@@ -8,7 +8,11 @@
 import Foundation
 
 struct PrivateURL {
-    static let openIssue = "http://52.79.159.39:8888/api/issues?isOpen=true"
-    static let allAssignee = "http://52.79.159.39:8888/api/assignees"
-    static let label = "http://52.79.159.39:8888/api/labels"
+    static let url = "http://52.79.159.39:8888/api"
+    static let openIssue = "/issues?isOpen=true"
+    static let closedIssue = "/issues?isOpen=false"
+    static let allAssignee = "/assignees"
+    static let label = "/labels"
+    static let milestone = "/milestones?status=open"
+    static let writer = "/writers"
 }


### PR DESCRIPTION
안녕하세요 강운! 벌써 이슈트레커 마지막날이네요. 한달동안 코드리뷰를 성의있게 달아주셔서 감사합니다. 덕분에 많은걸 알아갑니다.!! 이번주도 잘 부탁드립니다 😁

## 작업내용
### 💡3주차 코드리뷰 적용💡
* fetch메서드 삭제
* 최소버전 명시코드 삭제
* 그외 코드리뷰

### 💡필터뷰에 띄울 데이터 네트워킹 구현💡
* 열린이슈/닫힌이슈를 제외한 label/assignee/milestone/writer 데이터 받아오기
* 테이블뷰의 셀에 네트워킹 받아온 데이터를 나타냄

### 💡필터뷰 로직 구현💡
* 라디오 버튼과 같이 하나의 섹션에 하나의 셀만 체크할 수 있도록 설계
* 클릭 후 저장버튼을 누르면 해당하는 쿼리문 작성하는 메서드 구현
* 쿼리문을 통한 데이터 통신
* 통신으로 받아온 데이터를 이슈리스트 컬렉션뷰에 나타내고 리로드

### 💡서치바 구현💡
* UI까지만 구현 (로직X)

## 고민사항
* [버그] 셀을 클릭하고 스크롤을 컨트롤하여 화면에 사라졌다가 나타나면 클릭된 상태가 풀리는 에러가 있습니다.
재사용셀의 특성으로 파악하고 있으며, 클릭된 데이터를 저장하는 변수를 만들어서 해결할 예정입니다.

![Simulator Screen Recording - iPhone 14 Pro - 2023-06-02 at 11 07 16](https://github.com/codesquad-members-2023/issue-tracker/assets/97685264/0b86a55f-b1b8-47a0-b739-5867f0f23010)


* [버그] (해결) 필터를 사용하여 저장을 누를시 컬렉션뷰도 리유저블셀이라서 라벨이 누적되는 현상
셀에 있는 prepareForReuse메서드 사용하여 해결하였습니다. (재사용되는 셀의 속성을 초기화하는 기능)


## 최종 동작예시
![Simulator Screen Recording - iPhone 14 Pro - 2023-06-02 at 11 06 31](https://github.com/codesquad-members-2023/issue-tracker/assets/97685264/14f64282-9183-4ab0-af02-8af9374f7b29)

